### PR TITLE
ensure we analyze usages of the latest stable version

### DIFF
--- a/packages/corpus/README.md
+++ b/packages/corpus/README.md
@@ -32,6 +32,11 @@ Some available options are:
   public API), this option will include which package is using the `src/`
   library in the output
 
+Note that running this tool without a `--package-limit` means that it will
+process all the package dependencies from pub.dev; this could be a large
+number (you can always cancel the command at any time and re-run with a package
+limit).
+
 ```
 usage: dart bin/api_usage.dart [options] <package-name>
 

--- a/packages/corpus/README.md
+++ b/packages/corpus/README.md
@@ -31,8 +31,6 @@ Some available options are:
   directory (something that's generally not intended to be part of a package's
   public API), this option will include which package is using the `src/`
   library in the output
-- `--include-old`: Include packages that haven't been published in the last
-  year (these are normally excluded).
 
 ```
 usage: dart bin/api_usage.dart [options] <package-name>
@@ -41,5 +39,4 @@ options:
 -h, --help                     Print this usage information.
     --package-limit=<count>    Limit the number of packages usage data is collected from.
     --show-src-references      Report specific references to src/ libraries.
-    --include-old              Include packages that haven't been published in the last year (these are normally excluded).
 ```

--- a/packages/corpus/bin/api_usage.dart
+++ b/packages/corpus/bin/api_usage.dart
@@ -35,7 +35,7 @@ void main(List<String> args) async {
 
   final packageName = argResults.rest.first;
   final packageLimit =
-      int.tryParse(argResults['package-limit'] ?? '') ?? 0xffff;
+      int.tryParse(argResults['package-limit'] ?? '') ?? 0x7fffffff;
   bool showSrcReferences = argResults['show-src-references'] as bool;
 
   var log = Logger.standard();

--- a/packages/corpus/bin/api_usage.dart
+++ b/packages/corpus/bin/api_usage.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:cli_util/cli_logging.dart';
 import 'package:corpus/api.dart';
 import 'package:corpus/cache.dart';
@@ -33,9 +34,9 @@ void main(List<String> args) async {
   }
 
   final packageName = argResults.rest.first;
-  String? packageLimit = argResults['package-limit'];
+  final packageLimit =
+      int.tryParse(argResults['package-limit'] ?? '') ?? 0xffff;
   bool showSrcReferences = argResults['show-src-references'] as bool;
-  bool includeOld = argResults['include-old'] as bool;
 
   var log = Logger.standard();
 
@@ -49,27 +50,30 @@ void main(List<String> args) async {
 
   var targetPackage = await pub.getPackageInfo(packageName);
 
-  final dateOneYearAgo = DateTime.now().subtract(Duration(days: 365));
-  bool packageAgeFilter(PackageInfo packageInfo) {
-    // TODO: print to stdout when filtered a package
-
-    // Only use packages which have been updated in the last year.
-    return packageInfo.publishedDate.isAfter(dateOneYearAgo);
-  }
-
-  var packageStream = pub.popularDependenciesOf(
-    packageName,
-    limit: packageLimit == null ? null : int.parse(packageLimit),
-    filter: includeOld ? null : packageAgeFilter,
-  );
+  var packageStream = pub.popularDependenciesOf(packageName);
 
   progress.finish(showTiming: true);
 
   List<ApiUsage> usageInfo = [];
 
+  var count = 0;
+
   await for (var package in packageStream) {
     log.stdout('');
     log.stdout('${package.name} v${package.version}');
+
+    // Skip a package when its constraints don't include the latest stable.
+    var constraint = package.constraintFor(targetPackage.name);
+    if (constraint == null) {
+      log.stdout('skipping - no constraint on ${targetPackage.name}');
+      continue;
+    }
+    if (!constraint.allows(Version.parse(targetPackage.version))) {
+      log.stdout(
+          "skipping - version dep ($constraint) doesn't support the current "
+          'stable (${targetPackage.version})');
+      continue;
+    }
 
     bool downloadSuccess =
         await packageManager.retrievePackageArchive(package, logger: log);
@@ -86,12 +90,18 @@ void main(List<String> args) async {
       continue;
     }
 
+    count++;
+
     progress = log.progress('analyzing package');
     var usage =
         await analyzePackage(targetPackage, package, localPackage.directory);
     progress.finish(message: usage.describeUsage());
 
     usageInfo.add(usage);
+
+    if (count >= packageLimit) {
+      break;
+    }
   }
 
   var report = Report(targetPackage);
@@ -125,12 +135,6 @@ ArgParser createArgParser() {
     'show-src-references',
     negatable: false,
     help: 'Report specific references to src/ libraries.',
-  );
-  parser.addFlag(
-    'include-old',
-    negatable: false,
-    help: 'Include packages that haven\'t been published in the last year '
-        '(these are normally excluded).',
   );
   return parser;
 }

--- a/packages/corpus/doc/collection.md
+++ b/packages/corpus/doc/collection.md
@@ -8,7 +8,7 @@ Collections and utilities functions and classes related to collections.
 - docs: https://pub.dev/documentation/collection/latest/
 - dependent packages: https://pub.dev/packages?q=dependency%3Acollection&sort=top
 
-Stats for collection v1.16.0 pulled from 12 packages.
+Stats for collection v1.17.0 pulled from 100 packages.
 
 ## Library references
 
@@ -16,15 +16,15 @@ Stats for collection v1.16.0 pulled from 12 packages.
 
 | Library | Package references | % |
 | --- | ---: | ---: |
-| package:collection/collection.dart | 9 | 75% |
-| package:collection/src/iterable_extensions.dart | 1 | 8% |
+| package:collection/collection.dart | 95 | 95% |
+| package:collection/src/iterable_extensions.dart | 2 | 2% |
 
 ### Library references from libraries
 
 | Library | Library references | % |
 | --- | ---: | ---: |
-| package:collection/collection.dart | 45 | 65% |
-| package:collection/src/iterable_extensions.dart | 1 | 1% |
+| package:collection/collection.dart | 301 | 82% |
+| package:collection/src/iterable_extensions.dart | 2 | 1% |
 
 ## Class references
 
@@ -32,17 +32,49 @@ Stats for collection v1.16.0 pulled from 12 packages.
 
 | Class | Package references | % |
 | --- | ---: | ---: |
-| DeepCollectionEquality | 4 | 33% |
-| ListEquality | 2 | 17% |
-| MapEquality | 2 | 17% |
+| ListEquality | 20 | 20% |
+| DeepCollectionEquality | 16 | 16% |
+| MapEquality | 8 | 8% |
+| _UnorderedEquality | 5 | 5% |
+| _DelegatingIterableBase | 4 | 4% |
+| QueueList | 4 | 4% |
+| IterableEquality | 4 | 4% |
+| DelegatingList | 3 | 3% |
+| SetEquality | 3 | 3% |
+| UnmodifiableSetView | 3 | 3% |
+| UnorderedIterableEquality | 2 | 2% |
+| DefaultEquality | 2 | 2% |
+| CanonicalizedMap | 2 | 2% |
+| Equality | 2 | 2% |
+| UnmodifiableMapMixin | 1 | 1% |
+| PriorityQueue | 1 | 1% |
+| HeapPriorityQueue | 1 | 1% |
+| NonGrowableListMixin | 1 | 1% |
+| CombinedMapView | 1 | 1% |
 
 ### Class references from libraries
 
 | Class | Library references | % |
 | --- | ---: | ---: |
-| DeepCollectionEquality | 5 | 7% |
-| ListEquality | 2 | 3% |
-| MapEquality | 2 | 3% |
+| ListEquality | 40 | 11% |
+| DeepCollectionEquality | 37 | 10% |
+| MapEquality | 32 | 9% |
+| _DelegatingIterableBase | 22 | 6% |
+| Equality | 10 | 3% |
+| _UnorderedEquality | 8 | 2% |
+| DelegatingList | 7 | 2% |
+| SetEquality | 6 | 2% |
+| CanonicalizedMap | 5 | 1% |
+| QueueList | 4 | 1% |
+| IterableEquality | 4 | 1% |
+| UnmodifiableSetView | 4 | 1% |
+| UnmodifiableMapMixin | 2 | 1% |
+| UnorderedIterableEquality | 2 | 1% |
+| DefaultEquality | 2 | 1% |
+| NonGrowableListMixin | 2 | 1% |
+| PriorityQueue | 1 | 0% |
+| HeapPriorityQueue | 1 | 0% |
+| CombinedMapView | 1 | 0% |
 
 ## Extension references
 
@@ -50,23 +82,25 @@ Stats for collection v1.16.0 pulled from 12 packages.
 
 | Extension | Package references | % |
 | --- | ---: | ---: |
-| IterableExtension | 5 | 42% |
-| IterableNumberExtension | 2 | 17% |
-| IterableIntegerExtension | 1 | 8% |
-| IterableComparableExtension | 1 | 8% |
-| IterableNullableExtension | 1 | 8% |
-| ListExtensions | 1 | 8% |
+| IterableExtension | 48 | 48% |
+| ListExtensions | 13 | 13% |
+| IterableNullableExtension | 8 | 8% |
+| IterableNumberExtension | 4 | 4% |
+| IterableIntegerExtension | 3 | 3% |
+| IterableComparableExtension | 2 | 2% |
+| IterableDoubleExtension | 2 | 2% |
 
 ### Extension references from libraries
 
 | Extension | Library references | % |
 | --- | ---: | ---: |
-| IterableExtension | 37 | 54% |
-| IterableNullableExtension | 6 | 9% |
-| IterableIntegerExtension | 2 | 3% |
-| IterableComparableExtension | 2 | 3% |
-| IterableNumberExtension | 2 | 3% |
-| ListExtensions | 1 | 1% |
+| IterableExtension | 151 | 41% |
+| ListExtensions | 24 | 7% |
+| IterableNullableExtension | 18 | 5% |
+| IterableIntegerExtension | 5 | 1% |
+| IterableNumberExtension | 4 | 1% |
+| IterableComparableExtension | 3 | 1% |
+| IterableDoubleExtension | 3 | 1% |
 
 ## Top-level symbols
 
@@ -74,25 +108,131 @@ Stats for collection v1.16.0 pulled from 12 packages.
 
 | Top-level symbol | Package references | % |
 | --- | ---: | ---: |
-| equalsIgnoreAsciiCase | 1 | 8% |
+| groupBy | 4 | 4% |
+| equalsIgnoreAsciiCase | 2 | 2% |
+| compareAsciiLowerCase | 2 | 2% |
+| compareAsciiLowerCaseNatural | 2 | 2% |
+| mergeSort | 2 | 2% |
+| minBy | 1 | 1% |
+| compareNatural | 1 | 1% |
+| lowerBound | 1 | 1% |
+| binarySearch | 1 | 1% |
+| insertionSort | 1 | 1% |
 
 ### Top-level symbol references from libraries
 
 | Top-level symbol | Library references | % |
 | --- | ---: | ---: |
-| equalsIgnoreAsciiCase | 4 | 6% |
+| equalsIgnoreAsciiCase | 5 | 1% |
+| groupBy | 4 | 1% |
+| compareAsciiLowerCaseNatural | 3 | 1% |
+| compareAsciiLowerCase | 2 | 1% |
+| mergeSort | 2 | 1% |
+| minBy | 1 | 0% |
+| compareNatural | 1 | 0% |
+| lowerBound | 1 | 0% |
+| binarySearch | 1 | 0% |
+| insertionSort | 1 | 0% |
 
 ## Corpus packages
 
 - provider v6.0.4
 - cloud_firestore v3.5.1
 - equatable v2.0.5
+- get_it v7.2.0
 - flutter_riverpod v2.0.2
-- dart_code_metrics v4.21.0
+- dart_code_metrics v4.21.2
 - built_value v8.4.1
-- simple_animations v5.0.0+2
 - shelf v1.4.0
+- simple_animations v5.0.0+2
 - flutter_form_builder v7.7.0
 - flutter_map v3.0.0
 - mockito v5.3.2
 - hooks_riverpod v2.0.2
+- stacked v3.0.0
+- xml v6.1.0
+- mocktail v0.3.0
+- riverpod v2.0.2
+- yaml v3.1.1
+- adaptive_dialog v1.8.0+1
+- flutter_quill v6.0.8+1
+- objectbox v1.6.2
+- http_parser v4.0.2
+- palette_generator v0.3.3+2
+- sentry v6.13.0
+- process_run v0.12.3+2
+- routemaster v1.0.1
+- web3dart v2.4.1
+- pluto_grid v5.2.0
+- pub_semver v2.1.2
+- flex_color_picker v2.6.1
+- code_builder v4.3.0
+- telephony v0.2.0
+- intercom_flutter v7.5.0
+- storybook_flutter v0.11.2+2
+- spider v4.0.0
+- waterfall_flow v3.0.2
+- wiredash v1.5.0
+- graphs v2.1.0
+- signalr_netcore v1.3.3
+- dartdoc v6.1.2
+- puppeteer v2.14.0
+- rx_shared_preferences v3.0.0
+- currency_picker v2.0.12
+- jovial_svg v1.1.6
+- dart_ping v7.0.2
+- dropdown_textfield v1.0.5
+- drag_select_grid_view v0.6.1
+- functions_framework v0.4.1
+- slang v3.1.0
+- markdown_widget v1.3.0+2
+- elementary v1.5.0
+- flutter_slidable v2.0.0
+- yaru v0.4.2
+- form_bloc v0.30.0
+- go_router v5.1.0
+- flutter_cache_manager v3.3.0
+- scrollable_positioned_list v0.3.5
+- device_preview v1.1.0
+- introduction_screen v3.0.2
+- split_view v3.2.1
+- mobx v2.1.1
+- encrypt v5.0.1
+- async v2.9.0
+- responsive_framework v0.2.0
+- rive v0.9.1
+- test v1.21.6
+- intl_phone_number_input v0.7.1
+- freezed_annotation v2.2.0
+- new_version v0.3.1
+- optional v6.1.0+1
+- widget_mask v1.0.0+0
+- hydrated_bloc v8.1.0
+- flame v1.4.0
+- bdd_widget_test v1.4.2
+- syncfusion_flutter_datagrid v20.3.49
+- flutter_multi_formatter v2.8.0
+- loading_indicator v3.1.0
+- dartx v1.1.0
+- more v3.8.5
+- flinq v2.0.2
+- gpx v2.2.0
+- melos v2.7.1
+- flutter_layout_grid v2.0.1
+- protobuf v2.1.0
+- flutter_portal v1.1.1
+- gql_dio_link v0.2.3
+- country_picker v2.0.16
+- universal_io v2.0.4
+- back_button_interceptor v6.0.2
+- mapbox_gl v0.16.0
+- list_ext v1.0.6
+- youtube_explode_dart v1.12.1
+- markdown v6.0.1
+- flutter_background_geolocation v4.8.1
+- flutter_instagram_stories v1.0.2+1
+- adobe_xd v2.0.1
+- dds v2.4.0
+- cryptography v2.0.5
+- supercharged_dart v2.1.1
+- oauth2 v2.0.0

--- a/packages/corpus/lib/pub.dart
+++ b/packages/corpus/lib/pub.dart
@@ -21,13 +21,9 @@ class Pub {
     );
   }
 
-  Stream<PackageInfo> popularDependenciesOf(
-    String packageName, {
-    int? limit,
-  }) {
+  Stream<PackageInfo> popularDependenciesOf(String packageName) {
     return _packagesForSearch(
       'dependency:$packageName',
-      limit: limit,
       sort: 'top',
     );
   }
@@ -64,12 +60,9 @@ class Pub {
   Stream<PackageInfo> _packagesForSearch(
     String query, {
     int page = 1,
-    int? limit,
     String? sort,
   }) async* {
     final uri = Uri.parse('https://pub.dev/api/search');
-
-    int count = 0;
 
     for (;;) {
       final targetUri = uri.replace(queryParameters: {
@@ -85,21 +78,12 @@ class Pub {
           .map((e) => e['package'] as String?)) {
         var packageInfo = await getPackageInfo(packageName!);
 
-        count++;
         yield packageInfo;
-
-        if (limit != null && count >= limit) {
-          break;
-        }
       }
 
       if (map.containsKey('next')) {
         page = page + 1;
       } else {
-        break;
-      }
-
-      if (limit != null && count >= limit) {
         break;
       }
     }

--- a/packages/corpus/pubspec.yaml
+++ b/packages/corpus/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   collection: ^1.16.0
   http: ^0.13.0
   path: ^1.8.0
+  pub_semver: ^2.0.0
   surveyor:
     git:
       url: https://github.com/pq/surveyor

--- a/packages/corpus/pubspec.yaml
+++ b/packages/corpus/pubspec.yaml
@@ -1,5 +1,4 @@
 name: corpus
-version: 0.1.0
 description: A tool to calculate the API usage for a package.
 repository: https://github.com/dart-lang/ecosystem
 
@@ -13,7 +12,7 @@ dependencies:
   args: ^2.0.0
   cli_util: ^0.3.0
   collection: ^1.16.0
-  http: ^0.13.0
+  http: ^0.13.2
   path: ^1.8.0
   pub_semver: ^2.0.0
   surveyor:
@@ -27,5 +26,5 @@ dev_dependencies:
       url: https://github.com/dart-lang/test
       path: pkgs/checks
   lints: '>=1.0.0 <3.0.0'
-  test: ^1.16.0
+  test: ^1.22.0
   test_descriptor: ^2.0.0

--- a/packages/corpus/test/pub_test.dart
+++ b/packages/corpus/test/pub_test.dart
@@ -5,7 +5,9 @@
 import 'dart:convert';
 
 import 'package:checks/checks.dart';
+import 'package:checks/src/checks.dart' show ContextExtension, Rejection;
 import 'package:corpus/pub.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
@@ -17,8 +19,21 @@ void main() {
       checkThat(packageInfo.version).equals('4.0.2');
       checkThat(packageInfo.archiveUrl).isNotNull();
       checkThat(packageInfo.publishedDate).isNotNull();
+
+      checkThat(packageInfo.constraintFor('path')).isNotNull().allows('1.8.0');
+      checkThat(packageInfo.constraintFor('test')).isNotNull().allows('1.16.0');
     });
   });
+}
+
+extension VersionConstraintChecks on Check<VersionConstraint> {
+  void allows(String version) {
+    context.expect(() => const ['allows'], (VersionConstraint actual) {
+      final ver = Version.parse(version);
+      if (!actual.allows(ver)) return Rejection(actual: '$actual');
+      return null;
+    });
+  }
 }
 
 final String _pubSampleData = '''


### PR DESCRIPTION
- ensure we analyze usages of the latest stable version (fix #4)
- remove the `--include-old` flag (which was based on the date of last publish)
- make the `--package-limit` count more accurate
- update the most recent data from package:collection (our example output file)

For future work, we should break up `bin/api_usage.dart` to make it easier to test.
