### PR TITLE
add support for reporting usage information for dart: libraries

### DIFF
--- a/packages/corpus/README.md
+++ b/packages/corpus/README.md
@@ -26,16 +26,10 @@ dart bin/api_usage.dart <package-name>
 Some available options are:
 
 - `--package-limit`: limit the number of packages that are used for analysis
-  (this defaults to all referencing packages on pub.dev), 
 - `--show-src-references`: when there are references into a package's `lib/src/`
   directory (something that's generally not intended to be part of a package's
   public API), this option will include which package is using the `src/`
   library in the output
-
-Note that running this tool without a `--package-limit` means that it will
-process all the package dependencies from pub.dev; this could be a large
-number (you can always cancel the command at any time and re-run with a package
-limit).
 
 ```
 usage: dart bin/api_usage.dart [options] <package-name>
@@ -43,5 +37,6 @@ usage: dart bin/api_usage.dart [options] <package-name>
 options:
 -h, --help                     Print this usage information.
     --package-limit=<count>    Limit the number of packages usage data is collected from.
+                               (defaults to "100")
     --show-src-references      Report specific references to src/ libraries.
 ```

--- a/packages/corpus/bin/api_usage.dart
+++ b/packages/corpus/bin/api_usage.dart
@@ -26,8 +26,7 @@ void main(List<String> args) async {
   }
 
   final packageName = argResults.rest.first;
-  final packageLimit =
-      int.tryParse(argResults['package-limit'] ?? '') ?? 0x7FFFFFFF;
+  final packageLimit = int.tryParse(argResults['package-limit'])!;
   bool showSrcReferences = argResults['show-src-references'] as bool;
 
   await analyzeUsage(
@@ -47,6 +46,7 @@ ArgParser _createArgParser() {
   );
   parser.addOption(
     'package-limit',
+    defaultsTo: '100',
     aliases: ['limit'],
     help: 'Limit the number of packages usage data is collected from.',
     valueHelp: 'count',

--- a/packages/corpus/doc/dart_collection.md
+++ b/packages/corpus/doc/dart_collection.md
@@ -1,0 +1,80 @@
+# Report for dart:collection
+
+## General info
+
+https://api.dart.dev/dart-collection/dart-collection-library.html
+
+Stats for dart:collection v2.19.0 pulled from 10 packages.
+
+## Library references
+
+### Library references from packages
+
+| Library | Package references | % |
+| --- | ---: | ---: |
+| dart:collection | 10 | 100% |
+
+### Library references from libraries
+
+| Library | Library references | % |
+| --- | ---: | ---: |
+| dart:collection | 24 | 75% |
+
+## Class references
+
+### Class references from packages
+
+| Class | Package references | % |
+| --- | ---: | ---: |
+| UnmodifiableMapView | 3 | 30% |
+| LinkedHashMap | 3 | 30% |
+| ListMixin | 2 | 20% |
+| HashMap | 2 | 20% |
+| MapView | 2 | 20% |
+| LinkedHashSet | 2 | 20% |
+| MapBase | 2 | 20% |
+| ListBase | 2 | 20% |
+| MapMixin | 1 | 10% |
+| SetMixin | 1 | 10% |
+| HashSet | 1 | 10% |
+| IterableBase | 1 | 10% |
+| Queue | 1 | 10% |
+| SetBase | 1 | 10% |
+| LinkedList | 1 | 10% |
+| LinkedListEntry | 1 | 10% |
+| SplayTreeMap | 1 | 10% |
+
+### Class references from libraries
+
+| Class | Library references | % |
+| --- | ---: | ---: |
+| MapBase | 5 | 16% |
+| MapMixin | 4 | 13% |
+| UnmodifiableMapView | 4 | 13% |
+| ListMixin | 3 | 9% |
+| HashMap | 3 | 9% |
+| MapView | 3 | 9% |
+| LinkedHashMap | 3 | 9% |
+| LinkedHashSet | 3 | 9% |
+| ListBase | 3 | 9% |
+| SetMixin | 1 | 3% |
+| HashSet | 1 | 3% |
+| IterableBase | 1 | 3% |
+| Queue | 1 | 3% |
+| SetBase | 1 | 3% |
+| LinkedList | 1 | 3% |
+| LinkedListEntry | 1 | 3% |
+| SplayTreeMap | 1 | 3% |
+
+## Corpus packages
+
+- get v4.6.5
+- path v1.8.2
+- table_calendar v3.0.8
+- pdf v3.8.4
+- freezed v2.2.1
+- flutter_hooks v0.18.5+1
+- logging v1.1.0
+- shelf v1.4.0
+- awesome_notifications v0.7.4+1
+- googleapis v9.2.0

--- a/packages/corpus/doc/package_collection.md
+++ b/packages/corpus/doc/package_collection.md
@@ -8,7 +8,7 @@ Collections and utilities functions and classes related to collections.
 - docs: https://pub.dev/documentation/collection/latest/
 - dependent packages: https://pub.dev/packages?q=dependency%3Acollection&sort=top
 
-Stats for collection v1.17.0 pulled from 100 packages.
+Stats for package:collection v1.17.0 pulled from 100 packages.
 
 ## Library references
 
@@ -16,15 +16,15 @@ Stats for collection v1.17.0 pulled from 100 packages.
 
 | Library | Package references | % |
 | --- | ---: | ---: |
-| package:collection/collection.dart | 95 | 95% |
-| package:collection/src/iterable_extensions.dart | 2 | 2% |
+| package:collection/collection.dart | 96 | 96% |
+| package:collection/src/iterable_extensions.dart | 1 | 1% |
 
 ### Library references from libraries
 
 | Library | Library references | % |
 | --- | ---: | ---: |
-| package:collection/collection.dart | 301 | 82% |
-| package:collection/src/iterable_extensions.dart | 2 | 1% |
+| package:collection/collection.dart | 289 | 79% |
+| package:collection/src/iterable_extensions.dart | 1 | 0% |
 
 ## Class references
 
@@ -32,22 +32,22 @@ Stats for collection v1.17.0 pulled from 100 packages.
 
 | Class | Package references | % |
 | --- | ---: | ---: |
-| ListEquality | 20 | 20% |
-| DeepCollectionEquality | 16 | 16% |
+| ListEquality | 22 | 22% |
+| DeepCollectionEquality | 17 | 17% |
 | MapEquality | 8 | 8% |
-| _UnorderedEquality | 5 | 5% |
-| _DelegatingIterableBase | 4 | 4% |
+| _UnorderedEquality | 6 | 6% |
+| SetEquality | 4 | 4% |
 | QueueList | 4 | 4% |
 | IterableEquality | 4 | 4% |
-| DelegatingList | 3 | 3% |
-| SetEquality | 3 | 3% |
+| _DelegatingIterableBase | 3 | 3% |
 | UnmodifiableSetView | 3 | 3% |
+| DelegatingList | 2 | 2% |
 | UnorderedIterableEquality | 2 | 2% |
-| DefaultEquality | 2 | 2% |
 | CanonicalizedMap | 2 | 2% |
+| DefaultEquality | 2 | 2% |
+| PriorityQueue | 2 | 2% |
 | Equality | 2 | 2% |
 | UnmodifiableMapMixin | 1 | 1% |
-| PriorityQueue | 1 | 1% |
 | HeapPriorityQueue | 1 | 1% |
 | NonGrowableListMixin | 1 | 1% |
 | CombinedMapView | 1 | 1% |
@@ -56,23 +56,23 @@ Stats for collection v1.17.0 pulled from 100 packages.
 
 | Class | Library references | % |
 | --- | ---: | ---: |
-| ListEquality | 40 | 11% |
-| DeepCollectionEquality | 37 | 10% |
+| DeepCollectionEquality | 47 | 13% |
+| ListEquality | 42 | 12% |
 | MapEquality | 32 | 9% |
-| _DelegatingIterableBase | 22 | 6% |
+| _DelegatingIterableBase | 21 | 6% |
 | Equality | 10 | 3% |
-| _UnorderedEquality | 8 | 2% |
-| DelegatingList | 7 | 2% |
-| SetEquality | 6 | 2% |
+| _UnorderedEquality | 9 | 2% |
+| SetEquality | 7 | 2% |
 | CanonicalizedMap | 5 | 1% |
+| DelegatingList | 4 | 1% |
 | QueueList | 4 | 1% |
 | IterableEquality | 4 | 1% |
 | UnmodifiableSetView | 4 | 1% |
 | UnmodifiableMapMixin | 2 | 1% |
 | UnorderedIterableEquality | 2 | 1% |
 | DefaultEquality | 2 | 1% |
+| PriorityQueue | 2 | 1% |
 | NonGrowableListMixin | 2 | 1% |
-| PriorityQueue | 1 | 0% |
 | HeapPriorityQueue | 1 | 0% |
 | CombinedMapView | 1 | 0% |
 
@@ -82,25 +82,25 @@ Stats for collection v1.17.0 pulled from 100 packages.
 
 | Extension | Package references | % |
 | --- | ---: | ---: |
-| IterableExtension | 48 | 48% |
-| ListExtensions | 13 | 13% |
+| IterableExtension | 49 | 49% |
+| ListExtensions | 11 | 11% |
 | IterableNullableExtension | 8 | 8% |
-| IterableNumberExtension | 4 | 4% |
-| IterableIntegerExtension | 3 | 3% |
-| IterableComparableExtension | 2 | 2% |
-| IterableDoubleExtension | 2 | 2% |
+| IterableComparableExtension | 3 | 3% |
+| IterableNumberExtension | 3 | 3% |
+| IterableIntegerExtension | 2 | 2% |
+| IterableDoubleExtension | 1 | 1% |
 
 ### Extension references from libraries
 
 | Extension | Library references | % |
 | --- | ---: | ---: |
-| IterableExtension | 151 | 41% |
-| ListExtensions | 24 | 7% |
-| IterableNullableExtension | 18 | 5% |
-| IterableIntegerExtension | 5 | 1% |
-| IterableNumberExtension | 4 | 1% |
-| IterableComparableExtension | 3 | 1% |
-| IterableDoubleExtension | 3 | 1% |
+| IterableExtension | 134 | 37% |
+| ListExtensions | 18 | 5% |
+| IterableNullableExtension | 14 | 4% |
+| IterableComparableExtension | 6 | 2% |
+| IterableIntegerExtension | 4 | 1% |
+| IterableNumberExtension | 3 | 1% |
+| IterableDoubleExtension | 2 | 1% |
 
 ## Top-level symbols
 
@@ -108,131 +108,131 @@ Stats for collection v1.17.0 pulled from 100 packages.
 
 | Top-level symbol | Package references | % |
 | --- | ---: | ---: |
-| groupBy | 4 | 4% |
-| equalsIgnoreAsciiCase | 2 | 2% |
-| compareAsciiLowerCase | 2 | 2% |
-| compareAsciiLowerCaseNatural | 2 | 2% |
+| groupBy | 5 | 5% |
 | mergeSort | 2 | 2% |
+| equalsIgnoreAsciiCase | 1 | 1% |
 | minBy | 1 | 1% |
-| compareNatural | 1 | 1% |
+| compareAsciiLowerCase | 1 | 1% |
+| stronglyConnectedComponents | 1 | 1% |
 | lowerBound | 1 | 1% |
 | binarySearch | 1 | 1% |
 | insertionSort | 1 | 1% |
+| compareAsciiLowerCaseNatural | 1 | 1% |
 
 ### Top-level symbol references from libraries
 
 | Top-level symbol | Library references | % |
 | --- | ---: | ---: |
-| equalsIgnoreAsciiCase | 5 | 1% |
-| groupBy | 4 | 1% |
-| compareAsciiLowerCaseNatural | 3 | 1% |
-| compareAsciiLowerCase | 2 | 1% |
+| groupBy | 5 | 1% |
+| equalsIgnoreAsciiCase | 4 | 1% |
 | mergeSort | 2 | 1% |
 | minBy | 1 | 0% |
-| compareNatural | 1 | 0% |
+| compareAsciiLowerCase | 1 | 0% |
+| stronglyConnectedComponents | 1 | 0% |
 | lowerBound | 1 | 0% |
 | binarySearch | 1 | 0% |
 | insertionSort | 1 | 0% |
+| compareAsciiLowerCaseNatural | 1 | 0% |
 
 ## Corpus packages
 
 - provider v6.0.4
-- cloud_firestore v3.5.1
+- cloud_firestore v4.0.4
 - equatable v2.0.5
 - get_it v7.2.0
-- flutter_riverpod v2.0.2
-- dart_code_metrics v4.21.2
-- built_value v8.4.1
+- flutter_riverpod v2.1.1
+- dart_code_metrics v5.0.1
+- freezed v2.2.1
+- built_value v8.4.2
 - shelf v1.4.0
-- simple_animations v5.0.0+2
 - flutter_form_builder v7.7.0
+- simple_animations v5.0.0+2
 - flutter_map v3.0.0
-- mockito v5.3.2
-- hooks_riverpod v2.0.2
+- hooks_riverpod v2.1.1
+- xml v6.2.1
 - stacked v3.0.0
-- xml v6.1.0
 - mocktail v0.3.0
-- riverpod v2.0.2
+- riverpod v2.1.1
 - yaml v3.1.1
+- hydrated_bloc v9.0.0
 - adaptive_dialog v1.8.0+1
-- flutter_quill v6.0.8+1
-- objectbox v1.6.2
 - http_parser v4.0.2
+- flutter_quill v6.1.4
+- sentry v6.14.0
+- objectbox v1.6.2
 - palette_generator v0.3.3+2
-- sentry v6.13.0
+- network_info_plus v3.0.1
 - process_run v0.12.3+2
+- flutter_portal v1.1.2
+- country_picker v2.0.17
 - routemaster v1.0.1
 - web3dart v2.4.1
-- pluto_grid v5.2.0
+- pluto_grid v5.4.0
 - pub_semver v2.1.2
-- flex_color_picker v2.6.1
 - code_builder v4.3.0
+- oauth2 v2.0.1
+- flex_color_picker v2.6.1
+- alice v0.3.2
 - telephony v0.2.0
-- intercom_flutter v7.5.0
 - storybook_flutter v0.11.2+2
-- spider v4.0.0
+- intercom_flutter v7.5.0
+- built_value_generator v8.4.2
 - waterfall_flow v3.0.2
-- wiredash v1.5.0
-- graphs v2.1.0
 - signalr_netcore v1.3.3
-- dartdoc v6.1.2
-- puppeteer v2.14.0
+- wiredash v1.5.0
+- dart_json_mapper v2.2.7
+- awesome_select v6.0.0
+- graphs v2.2.0
+- puppeteer v2.17.0
+- functions_framework v0.4.1
+- dropdown_textfield v1.0.6
+- dart_ping v7.0.2
+- jovial_svg v1.1.6
 - rx_shared_preferences v3.0.0
 - currency_picker v2.0.12
-- jovial_svg v1.1.6
-- dart_ping v7.0.2
-- dropdown_textfield v1.0.5
+- grinder v0.9.2
+- slang v3.3.1
 - drag_select_grid_view v0.6.1
-- functions_framework v0.4.1
-- slang v3.1.0
 - markdown_widget v1.3.0+2
-- elementary v1.5.0
+- linter v1.29.0
+- charts_painter v3.0.0
 - flutter_slidable v2.0.0
-- yaru v0.4.2
-- form_bloc v0.30.0
-- go_router v5.1.0
+- go_router v5.1.5
+- yaru v0.4.3
+- split_view v3.2.1
 - flutter_cache_manager v3.3.0
 - scrollable_positioned_list v0.3.5
+- optional v6.1.0+1
+- encrypt v5.0.1
 - device_preview v1.1.0
 - introduction_screen v3.0.2
-- split_view v3.2.1
 - mobx v2.1.1
-- encrypt v5.0.1
-- async v2.9.0
+- async v2.10.0
 - responsive_framework v0.2.0
+- mockito v5.3.2
+- elementary v1.5.0
 - rive v0.9.1
-- test v1.21.6
-- intl_phone_number_input v0.7.1
 - freezed_annotation v2.2.0
+- intl_phone_number_input v0.7.1
 - new_version v0.3.1
-- optional v6.1.0+1
-- widget_mask v1.0.0+0
-- hydrated_bloc v8.1.0
-- flame v1.4.0
-- bdd_widget_test v1.4.2
-- syncfusion_flutter_datagrid v20.3.49
-- flutter_multi_formatter v2.8.0
-- loading_indicator v3.1.0
-- dartx v1.1.0
+- form_bloc v0.30.0
+- flutter_multi_formatter v2.9.4
 - more v3.8.5
-- flinq v2.0.2
-- gpx v2.2.0
-- melos v2.7.1
-- flutter_layout_grid v2.0.1
-- protobuf v2.1.0
-- flutter_portal v1.1.1
+- melos v2.8.0
+- syncfusion_flutter_datagrid v20.3.56
+- flame v1.4.0
+- loading_indicator v3.1.0
+- widget_mask v1.0.0+0
+- dartx v1.1.0
 - gql_dio_link v0.2.3
-- country_picker v2.0.16
+- protobuf v2.1.0
+- flutter_layout_grid v2.0.1
+- flinq v2.0.2
 - universal_io v2.0.4
 - back_button_interceptor v6.0.2
 - mapbox_gl v0.16.0
-- list_ext v1.0.6
-- youtube_explode_dart v1.12.1
+- flutter_background_geolocation v4.8.3
+- gpx v2.2.0
 - markdown v6.0.1
-- flutter_background_geolocation v4.8.1
-- flutter_instagram_stories v1.0.2+1
-- adobe_xd v2.0.1
-- dds v2.4.0
 - cryptography v2.0.5
-- supercharged_dart v2.1.1
-- oauth2 v2.0.0
+- list_ext v1.0.6

--- a/packages/corpus/lib/api.dart
+++ b/packages/corpus/lib/api.dart
@@ -134,7 +134,7 @@ class ApiUseCollector extends RecursiveAstVisitor implements SurveyorVisitor {
     if (uri != null && uri.startsWith('$targetType:')) {
       bool matches;
 
-      if (reportTarget.isDartLibrary) {
+      if (reportTarget is DartLibraryTarget) {
         matches = uri == 'dart:$targetName';
       } else {
         matches = uri.startsWith('package:$targetName/');

--- a/packages/corpus/lib/api_usage.dart
+++ b/packages/corpus/lib/api_usage.dart
@@ -17,22 +17,39 @@ import 'surveyor.dart';
 
 Future analyzeUsage({
   required String packageName,
-  int packageLimit = 0x7FFFFFFF,
+  required int packageLimit,
   bool showSrcReferences = false,
 }) async {
   var log = Logger.standard();
 
-  log.stdout('API usage analysis for package:$packageName.');
-  log.stdout('');
+  var dartLibStrategy = packageName.startsWith('dart:');
+  if (dartLibStrategy) {
+    packageName = packageName.substring('dart:'.length);
+
+    log.stdout('API usage analysis for dart:$packageName.');
+    log.stdout('');
+  } else {
+    log.stdout('API usage analysis for package:$packageName.');
+    log.stdout('');
+  }
 
   var pub = Pub();
   var packageManager = PackageManager();
 
   var progress = log.progress('querying pub.dev');
 
-  var targetPackage = await pub.getPackageInfo(packageName);
+  var sdkVersion = Platform.version;
+  if (sdkVersion.contains('-')) {
+    sdkVersion = sdkVersion.substring(0, sdkVersion.indexOf('-'));
+  }
 
-  var packageStream = pub.popularDependenciesOf(packageName);
+  var reportTarget = dartLibStrategy
+      ? ReportTarget.fromDartLibrary(packageName, sdkVersion)
+      : ReportTarget.fromPackage(await pub.getPackageInfo(packageName));
+
+  var packageStream = dartLibStrategy
+      ? pub.allPubPackages()
+      : pub.popularDependenciesOf(packageName);
 
   progress.finish(showTiming: true);
 
@@ -44,17 +61,30 @@ Future analyzeUsage({
     log.stdout('');
     log.stdout('${package.name} v${package.version}');
 
-    // Skip a package when its constraints don't include the latest stable.
-    var constraint = package.constraintFor(targetPackage.name);
-    if (constraint == null) {
-      log.stdout('skipping - no constraint on ${targetPackage.name}');
-      continue;
-    }
-    if (!constraint.allows(Version.parse(targetPackage.version))) {
-      log.stdout(
-          "skipping - version dep ($constraint) doesn't support the current "
-          'stable (${targetPackage.version})');
-      continue;
+    if (reportTarget.isPackage) {
+      var targetPackage = reportTarget.targetPackage!;
+      // Skip a package when its constraints don't include the latest stable.
+      var constraint = package.constraintFor(targetPackage.name);
+      if (constraint == null) {
+        log.stdout('skipping - no constraint on ${targetPackage.name}');
+        continue;
+      }
+      if (!constraint.allows(Version.parse(targetPackage.version))) {
+        log.stdout(
+            "skipping - version dep ($constraint) doesn't support the current "
+            'stable (${targetPackage.version})');
+        continue;
+      }
+    } else {
+      var sdkConstraint = package.sdkContraint;
+      if (sdkConstraint != null) {
+        if (!sdkConstraint.allows(Version.parse(sdkVersion))) {
+          log.stdout(
+              "skipping - sdk constraint ($sdkConstraint) doesn't support the "
+              'current sdk ($sdkVersion)');
+          continue;
+        }
+      }
     }
 
     bool downloadSuccess =
@@ -72,12 +102,26 @@ Future analyzeUsage({
       continue;
     }
 
-    count++;
-
     progress = log.progress('analyzing package');
-    var usage =
-        await _analyzePackage(targetPackage, package, localPackage.directory);
-    progress.finish(message: usage.describeUsage());
+    var usage = await _analyzePackage(
+      reportTarget,
+      package,
+      localPackage.directory,
+    );
+    var message = usage.describeUsage();
+    if (reportTarget.isDartLibrary && !usage.hadAnyReferences) {
+      message = 'skipping - no dart:${reportTarget.name} references';
+    }
+    progress.finish(message: message);
+
+    // If collecting usage data for a dart: library, we check if the package
+    // we've just analyzed references the dart: lib. We do this after the fact
+    // as we don't know ahead of time wrt dart: usage.
+    if (reportTarget.isDartLibrary && !usage.hadAnyReferences) {
+      continue;
+    }
+
+    count++;
 
     usageInfo.add(usage);
 
@@ -86,7 +130,7 @@ Future analyzeUsage({
     }
   }
 
-  var report = Report(targetPackage);
+  var report = Report(reportTarget);
   var file = report.generateReport(
     usageInfo,
     showSrcReferences: showSrcReferences,
@@ -101,24 +145,27 @@ Future analyzeUsage({
 }
 
 Future<ApiUsage> _analyzePackage(
-  PackageInfo targetPackage,
-  PackageInfo usingPackage,
+  ReportTarget reportTarget,
+  PackageInfo analyzingPackage,
   Directory usingPackageDir,
 ) async {
   var cache = Cache();
   var file = File(path.join(
     cache.usageDir.path,
-    '${targetPackage.name}-${targetPackage.version}',
-    '${usingPackage.name}-${usingPackage.version}.json',
+    '${reportTarget.type}-${reportTarget.name}-${reportTarget.version}',
+    '${analyzingPackage.name}-${analyzingPackage.version}.json',
   ));
 
   if (file.existsSync()) {
-    ApiUsage usage = ApiUsage.fromFile(usingPackage, file);
+    ApiUsage usage = ApiUsage.fromFile(analyzingPackage, file);
     return usage;
   }
 
-  var apiUsageCollector =
-      ApiUseCollector(targetPackage, usingPackage, usingPackageDir);
+  var apiUsageCollector = ApiUseCollector(
+    reportTarget,
+    analyzingPackage,
+    usingPackageDir,
+  );
 
   var surveyor = Surveyor.fromDirs(
     directories: [usingPackageDir],

--- a/packages/corpus/lib/api_usage.dart
+++ b/packages/corpus/lib/api_usage.dart
@@ -22,34 +22,30 @@ Future analyzeUsage({
 }) async {
   var log = Logger.standard();
 
-  var dartLibStrategy = packageName.startsWith('dart:');
-  if (dartLibStrategy) {
-    packageName = packageName.substring('dart:'.length);
-
-    log.stdout('API usage analysis for dart:$packageName.');
-    log.stdout('');
-  } else {
-    log.stdout('API usage analysis for package:$packageName.');
-    log.stdout('');
-  }
-
   var pub = Pub();
   var packageManager = PackageManager();
-
-  var progress = log.progress('querying pub.dev');
 
   var sdkVersion = Platform.version;
   if (sdkVersion.contains('-')) {
     sdkVersion = sdkVersion.substring(0, sdkVersion.indexOf('-'));
   }
 
-  var reportTarget = dartLibStrategy
-      ? ReportTarget.fromDartLibrary(packageName, sdkVersion)
-      : ReportTarget.fromPackage(await pub.getPackageInfo(packageName));
+  ReportTarget reportTarget;
+  if (packageName.startsWith('dart:')) {
+    var nameWithoutPrefix = packageName.substring('dart:'.length);
+    reportTarget =
+        DartLibraryTarget(name: nameWithoutPrefix, version: sdkVersion);
+  } else {
+    var packageInfo = await pub.getPackageInfo(packageName);
+    reportTarget = PackageTarget.fromPackage(packageInfo);
+  }
 
-  var packageStream = dartLibStrategy
-      ? pub.allPubPackages()
-      : pub.popularDependenciesOf(packageName);
+  log.stdout('API usage analysis for $reportTarget.');
+  log.stdout('');
+
+  var progress = log.progress('querying pub.dev');
+
+  var packageStream = reportTarget.getPackages(pub);
 
   progress.finish(showTiming: true);
 
@@ -61,8 +57,8 @@ Future analyzeUsage({
     log.stdout('');
     log.stdout('${package.name} v${package.version}');
 
-    if (reportTarget.isPackage) {
-      var targetPackage = reportTarget.targetPackage!;
+    if (reportTarget is PackageTarget) {
+      var targetPackage = reportTarget.targetPackage;
       // Skip a package when its constraints don't include the latest stable.
       var constraint = package.constraintFor(targetPackage.name);
       if (constraint == null) {
@@ -109,7 +105,9 @@ Future analyzeUsage({
       localPackage.directory,
     );
     var message = usage.describeUsage();
-    if (reportTarget.isDartLibrary && !usage.hadAnyReferences) {
+    var hasNoUsage =
+        reportTarget is DartLibraryTarget && !usage.hadAnyReferences;
+    if (hasNoUsage) {
       message = 'skipping - no dart:${reportTarget.name} references';
     }
     progress.finish(message: message);
@@ -117,21 +115,19 @@ Future analyzeUsage({
     // If collecting usage data for a dart: library, we check if the package
     // we've just analyzed references the dart: lib. We do this after the fact
     // as we don't know ahead of time wrt dart: usage.
-    if (reportTarget.isDartLibrary && !usage.hadAnyReferences) {
+    if (hasNoUsage) {
       continue;
     }
 
-    count++;
-
     usageInfo.add(usage);
 
+    count++;
     if (count >= packageLimit) {
       break;
     }
   }
 
-  var report = Report(reportTarget);
-  var file = report.generateReport(
+  var file = Report(reportTarget).generateReport(
     usageInfo,
     showSrcReferences: showSrcReferences,
   );

--- a/packages/corpus/lib/pub.dart
+++ b/packages/corpus/lib/pub.dart
@@ -231,12 +231,9 @@ class PackageInfo {
   }
 
   VersionConstraint? get sdkContraint {
-    var environment = _pubspec['environment'] as Map?;
-    if (environment == null) return null;
-
-    var sdk = environment['sdk'] as String?;
+    var environment = (_pubspec['environment'] as Map?);
+    var sdk = environment?['sdk'] as String?;
     if (sdk == null) return null;
-
     return VersionConstraint.parse(sdk);
   }
 

--- a/packages/corpus/test/data/dart_extension_references.dart
+++ b/packages/corpus/test/data/dart_extension_references.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+void main() {
+  Future? future;
+  print(future?..ignore());
+}

--- a/packages/corpus/test/data/dart_library_references.dart
+++ b/packages/corpus/test/data/dart_library_references.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+void main() {
+  var map = SplayTreeMap<String, int>();
+  map['one'] = 1;
+  map['two'] = 2;
+  map['three'] = 3;
+  print(map);
+
+  dynamic local;
+  Queue.castFrom(local);
+}

--- a/packages/corpus/test/data/dart_top_level_symbol_references.dart
+++ b/packages/corpus/test/data/dart_top_level_symbol_references.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+void main() {
+  print(base64);
+  print(jsonDecode('{}'));
+}

--- a/packages/corpus/test/visitor_test.dart
+++ b/packages/corpus/test/visitor_test.dart
@@ -20,7 +20,7 @@ void main() {
         'pubspec': <String, dynamic>{},
       }
     });
-    ReportTarget reportTarget = ReportTarget.fromPackage(targetPackage);
+    ReportTarget reportTarget = PackageTarget.fromPackage(targetPackage);
     PackageInfo referencingPackage = PackageInfo.from({'name': 'foo'});
     Directory packageDir = Directory('test/data');
 
@@ -71,7 +71,7 @@ void main() {
 
     test('extension references', () async {
       apiUsageCollector = ApiUseCollector(
-        ReportTarget.fromPackage(PackageInfo.from({
+        PackageTarget.fromPackage(PackageInfo.from({
           'name': 'collection',
           'latest': {
             'version': '0.1.2',
@@ -118,8 +118,10 @@ void main() {
   });
 
   group('ApiUseCollector - dart:', () {
-    ReportTarget reportTarget =
-        ReportTarget.fromDartLibrary('collection', _sdkVersion);
+    ReportTarget reportTarget = DartLibraryTarget(
+      name: 'collection',
+      version: _sdkVersion,
+    );
     PackageInfo referencingPackage = PackageInfo.from({'name': 'foo'});
     Directory packageDir = Directory('test/data');
 
@@ -170,7 +172,7 @@ void main() {
 
     test('top-level symbol references', () async {
       apiUsageCollector = ApiUseCollector(
-        ReportTarget.fromDartLibrary('convert', _sdkVersion),
+        DartLibraryTarget(name: 'convert', version: _sdkVersion),
         referencingPackage,
         packageDir,
       );
@@ -199,7 +201,7 @@ void main() {
 
     test('extension references', () async {
       apiUsageCollector = ApiUseCollector(
-        ReportTarget.fromDartLibrary('async', _sdkVersion),
+        DartLibraryTarget(name: 'async', version: _sdkVersion),
         referencingPackage,
         packageDir,
       );


### PR DESCRIPTION
This adds support for reporting usage information for dart: libraries:
- let the user specify `dart:foo` on the command line
- use pub.dev as the corpus for dart: libraries (for this, we don't know which packages use the dart library ahead of time; we now download all the packages and only include them in the corpus if they do turn out to reference the library) 
- always use a package limit now (due to there being no inherent limit for dart: libraries, unlike package: references)
- add an abstraction - `ReportTarget` - that can refer to either a package: or and a dart: library, and pass that abstraction through where we'd previously just used a PackageInfo
- double up the tests to also check for dart: support
- commit updated sample report files in the `doc/` dir (done as a separate commit to make the review easier)

I'm not 100% sold on using `Pub.allPubPackages()` as the corpus for dart: libraries; it's much slower than analyzing for packages as we download and analyze several times more packages than we need to. I don't have a better idea though; perhaps the impl. can be optimized.
