### PR TITLE
use dart_flutter_team_lints in this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository is home to general Dart Ecosystem tools and packages.
 
 ## Packages
 
-| Package | Description | Published Version |
-| --- | --- | --- |
-| [blast_repo](pkgs/blast_repo/) |  | --- |
-| [corpus](pkgs/corpus/) | A tool to calculate the API usage for a package. | --- |
-| [dart_flutter_team_lints](pkgs/dart_flutter_team_lints/) | An analysis rule set used by the Dart and Flutter teams. | --- |
+| Package | Description | Version |
+|---|---|---|
+| [blast_repo](pkgs/blast_repo/) | A tool to bulk validate and fix GitHub repos. |  |
+| [corpus](pkgs/corpus/) | A tool to calculate the API usage for a package. |  |
+| [dart_flutter_team_lints](pkgs/dart_flutter_team_lints/) | An analysis rule set used by the Dart and Flutter teams. | [![pub package](https://img.shields.io/pub/v/dart_flutter_team_lints.svg)](https://pub.dev/packages/dart_flutter_team_lints) |

--- a/pkgs/blast_repo/analysis_options.yaml
+++ b/pkgs/blast_repo/analysis_options.yaml
@@ -1,49 +1,7 @@
-include: package:lints/recommended.yaml
+include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
-
-linter:
-  rules:
-    - always_declare_return_types
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_classes_with_only_static_members
-    - avoid_dynamic_calls
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_returning_null
-    - avoid_returning_null_for_future
-    - avoid_returning_this
-    - avoid_unused_constructor_parameters
-    - cancel_subscriptions
-    - cascade_invocations
-    - comment_references
-    - directives_ordering
-    - join_return_with_assignment
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_runtimeType_toString
-    - omit_local_variable_types
-    - only_throw_errors
-    - package_api_docs
-    - prefer_asserts_in_initializer_lists
-    - prefer_const_constructors
-    - prefer_const_declarations
-    - prefer_expression_function_bodies
-    - prefer_final_locals
-    - prefer_interpolation_to_compose_strings
-    - prefer_relative_imports
-    - prefer_single_quotes
-    - require_trailing_commas
-    - sort_pub_dependencies
-    - test_types_in_equals
-    - throw_in_finally
-    - unawaited_futures
-    - unnecessary_lambdas
-    - unnecessary_null_aware_assignments
-    - unnecessary_parenthesis
-    - unnecessary_statements
-    - use_string_buffers

--- a/pkgs/blast_repo/lib/src/tweaks/github_action_tweak.dart
+++ b/pkgs/blast_repo/lib/src/tweaks/github_action_tweak.dart
@@ -123,7 +123,8 @@ Future<List<String>> _fixFile(
           );
 
           items.add(
-            'Updated ${path.join('/')} from $currentVersion to $targetActionVersion',
+            'Updated ${path.join('/')} from $currentVersion to '
+            '$targetActionVersion',
           );
         }
       }

--- a/pkgs/blast_repo/pubspec.yaml
+++ b/pkgs/blast_repo/pubspec.yaml
@@ -1,4 +1,5 @@
 name: blast_repo
+description: A tool to bulk validate and fix GitHub repos.
 publish_to: none
 
 environment:
@@ -18,8 +19,12 @@ dependencies:
   yaml_edit: ^2.0.3
 
 dev_dependencies:
-  lints: ^2.0.0
+  dart_flutter_team_lints: ^0.1.0
   test: ^1.22.0
 
 executables:
   blast_repo:
+
+dependency_overrides:
+  dart_flutter_team_lints:
+    path: ../dart_flutter_team_lints

--- a/pkgs/corpus/analysis_options.yaml
+++ b/pkgs/corpus/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lints/recommended.yaml
+include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   exclude:

--- a/pkgs/corpus/bin/api_usage.dart
+++ b/pkgs/corpus/bin/api_usage.dart
@@ -27,7 +27,7 @@ void main(List<String> args) async {
 
   final packageName = argResults.rest.first;
   final packageLimit = int.tryParse(argResults['package-limit'])!;
-  bool showSrcReferences = argResults['show-src-references'] as bool;
+  var showSrcReferences = argResults['show-src-references'] as bool;
 
   await analyzeUsage(
     packageName: packageName,

--- a/pkgs/corpus/bin/deps.dart
+++ b/pkgs/corpus/bin/deps.dart
@@ -34,7 +34,7 @@ void main(List<String> args) async {
 
   final packageName = argResults.rest.first;
   String? packageLimit = argResults['package-limit'];
-  bool excludeOld = argResults['exclude-old'] as bool;
+  var excludeOld = argResults['exclude-old'] as bool;
 
   var log = Logger.standard();
 
@@ -61,7 +61,7 @@ void main(List<String> args) async {
 
   var usageInfos = <PackageUsageInfo>[];
 
-  int count = 0;
+  var count = 0;
 
   for (var package in packages) {
     progress = log.progress('  $package');

--- a/pkgs/corpus/lib/api.dart
+++ b/pkgs/corpus/lib/api.dart
@@ -45,7 +45,7 @@ class ApiUsage {
   }
 
   void toFile(File file) {
-    Map json = {
+    var json = {
       'packages': fromPackages.toJson(),
       'libraries': fromLibraries.toJson(),
     };
@@ -58,11 +58,12 @@ class ApiUsage {
   }
 
   String describeUsage() {
-    int libraryCount = fromPackages.sortedLibraryReferences.length;
-    int classCount = fromPackages.sortedClassReferences.length;
-    int extensionCount = fromPackages.sortedExtensionReferences.length;
-    int symbolCount = fromPackages.sortedTopLevelReferences.length;
-    return 'referenced $libraryCount ${pluralize(libraryCount, 'library', plural: 'libraries')}, '
+    var libraryCount = fromPackages.sortedLibraryReferences.length;
+    var classCount = fromPackages.sortedClassReferences.length;
+    var extensionCount = fromPackages.sortedExtensionReferences.length;
+    var symbolCount = fromPackages.sortedTopLevelReferences.length;
+    var librariesStr = pluralize(libraryCount, 'library', plural: 'libraries');
+    return 'referenced $libraryCount $librariesStr, '
         '$classCount ${pluralize(classCount, 'class', plural: 'classes')}, '
         '$extensionCount ${pluralize(extensionCount, 'extension')}, '
         'and $symbolCount top-level ${pluralize(symbolCount, 'symbol')}';
@@ -415,7 +416,7 @@ class EntityReferences {
   Map<String, int> get sortedReferences => _sortByCount(_references);
 
   Map<String, int> _sortByCount(Map<String, Set<Entity>> refs) {
-    List<String> keys = refs.keys.toList();
+    var keys = refs.keys.toList();
     keys.sort((a, b) => refs[b]!.length - refs[a]!.length);
     return Map.fromIterable(keys, value: (key) => refs[key]!.length);
   }

--- a/pkgs/corpus/lib/api_usage.dart
+++ b/pkgs/corpus/lib/api_usage.dart
@@ -49,7 +49,7 @@ Future analyzeUsage({
 
   progress.finish(showTiming: true);
 
-  List<ApiUsage> usageInfo = [];
+  var usageInfo = <ApiUsage>[];
 
   var count = 0;
 
@@ -83,7 +83,7 @@ Future analyzeUsage({
       }
     }
 
-    bool downloadSuccess =
+    var downloadSuccess =
         await packageManager.retrievePackageArchive(package, logger: log);
     if (!downloadSuccess) {
       log.stdout('error downloading ${package.archiveUrl}');
@@ -153,7 +153,7 @@ Future<ApiUsage> _analyzePackage(
   ));
 
   if (file.existsSync()) {
-    ApiUsage usage = ApiUsage.fromFile(analyzingPackage, file);
+    var usage = ApiUsage.fromFile(analyzingPackage, file);
     return usage;
   }
 

--- a/pkgs/corpus/lib/packages.dart
+++ b/pkgs/corpus/lib/packages.dart
@@ -42,14 +42,14 @@ class PackageManager {
     var progress =
         logger?.progress('downloading ${path.basename(archiveFile.path)}');
     try {
-      Uint8List data = await _getPackageTarGzArchive(package);
+      var data = await _getPackageTarGzArchive(package);
       archiveFile.writeAsBytesSync(data);
       return true;
     } finally {
       progress?.finish(showTiming: true);
     }
 
-    // This is live as _getPackageTarGzArchive can throw.
+    // This is live as _getPackageTarGzArchive() can throw.
     // ignore: dead_code
     return false;
   }

--- a/pkgs/corpus/lib/pub.dart
+++ b/pkgs/corpus/lib/pub.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'dart:convert';
 
 import 'package:http/http.dart';
@@ -110,7 +112,7 @@ class Pub {
   }) async* {
     final uri = Uri.parse('https://pub.dev/api/search');
 
-    int count = 0;
+    var count = 0;
 
     for (;;) {
       final targetUri = uri.replace(queryParameters: {
@@ -190,7 +192,8 @@ class PackageInfo {
   String? get homepage => _pubspec['homepage'];
 
   String? get repo => repository ?? homepage;
-  String? get sdkConstraint => (_pubspec['environment'] ?? {})['sdk'];
+  Map<String, dynamic>? get environment => _pubspec['environment'];
+  String? get sdkConstraint => (environment ?? {})['sdk'];
 
   String get version => _latest['version'];
   String get archiveUrl => _latest['archive_url'];
@@ -231,7 +234,7 @@ class PackageInfo {
   }
 
   VersionConstraint? get sdkContraint {
-    var environment = (_pubspec['environment'] as Map?);
+    var environment = _pubspec['environment'] as Map?;
     var sdk = environment?['sdk'] as String?;
     if (sdk == null) return null;
     return VersionConstraint.parse(sdk);

--- a/pkgs/corpus/pubspec.yaml
+++ b/pkgs/corpus/pubspec.yaml
@@ -22,6 +22,10 @@ dev_dependencies:
     git:
       url: https://github.com/dart-lang/test
       path: pkgs/checks
-  lints: ^2.0.0
+  dart_flutter_team_lints: ^0.1.0
   test: ^1.22.0
   test_descriptor: ^2.0.0
+
+dependency_overrides:
+  dart_flutter_team_lints:
+    path: ../dart_flutter_team_lints

--- a/pkgs/corpus/test/api_test.dart
+++ b/pkgs/corpus/test/api_test.dart
@@ -17,7 +17,8 @@ void main() {
     late ApiUsage sampleUsage;
 
     setUp(() {
-      var json = JsonDecoder().convert(_sampleUsageJson);
+      var json =
+          JsonDecoder().convert(_sampleUsageJson) as Map<String, dynamic>;
       sampleUsage = ApiUsage(
         PackageInfo.from(JsonDecoder().convert(_packageInfoJson)),
         References.fromJson(json['packages']),

--- a/pkgs/corpus/test/visitor_test.dart
+++ b/pkgs/corpus/test/visitor_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('ApiUseCollector - packages', () {
-    PackageInfo targetPackage = PackageInfo.from({
+    var targetPackage = PackageInfo.from({
       'name': 'path',
       'latest': {
         'version': '0.1.2',
@@ -21,8 +21,8 @@ void main() {
       }
     });
     ReportTarget reportTarget = PackageTarget.fromPackage(targetPackage);
-    PackageInfo referencingPackage = PackageInfo.from({'name': 'foo'});
-    Directory packageDir = Directory('test/data');
+    var referencingPackage = PackageInfo.from({'name': 'foo'});
+    var packageDir = Directory('test/data');
 
     late ApiUseCollector apiUsageCollector;
 
@@ -122,8 +122,8 @@ void main() {
       name: 'collection',
       version: _sdkVersion,
     );
-    PackageInfo referencingPackage = PackageInfo.from({'name': 'foo'});
-    Directory packageDir = Directory('test/data');
+    var referencingPackage = PackageInfo.from({'name': 'foo'});
+    var packageDir = Directory('test/data');
 
     late ApiUseCollector apiUsageCollector;
 

--- a/pkgs/dart_flutter_team_lints/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/dart_flutter_team_lints/test/validate_test.dart
+++ b/pkgs/dart_flutter_team_lints/test/validate_test.dart
@@ -20,12 +20,12 @@ void main() {
   });
 
   test('references recommended', () {
-    var result = yaml.loadYaml(content);
+    var result = yaml.loadYaml(content) as Map<String, dynamic>;
     expect(result['include'], equals('package:lints/recommended.yaml'));
   });
 
   test('defines linter rules', () {
-    var result = yaml.loadYaml(content);
-    expect(result['linter']['rules'], isNotEmpty);
+    var result = yaml.loadYaml(content) as Map<String, dynamic>;
+    expect((result['linter'] as Map)['rules'], isNotEmpty);
   });
 }

--- a/pkgs/dart_flutter_team_lints/test/validate_test.dart
+++ b/pkgs/dart_flutter_team_lints/test/validate_test.dart
@@ -20,12 +20,12 @@ void main() {
   });
 
   test('references recommended', () {
-    var result = yaml.loadYaml(content) as Map<String, dynamic>;
+    var result = yaml.loadYaml(content) as yaml.YamlMap;
     expect(result['include'], equals('package:lints/recommended.yaml'));
   });
 
   test('defines linter rules', () {
-    var result = yaml.loadYaml(content) as Map<String, dynamic>;
+    var result = yaml.loadYaml(content) as yaml.YamlMap;
     expect((result['linter'] as Map)['rules'], isNotEmpty);
   });
 }


### PR DESCRIPTION
- use dart_flutter_team_lints.svg in this repo

This updates the two other packages in this repo to use the local definition of `package:dart_flutter_team_lints`.

I found `omit_local_variable_types` useful - it located several places (in `corpus`) where I had unintentionally used types. `lines_longer_than_80_chars` was more annoying than useful; as everything is already formatted, it only found places where it was tough to get the line shorter than 80 chars.
