### PR TITLE
add strict-casts to dart_flutter_team_lints

### DIFF
--- a/pkgs/blast_repo/analysis_options.yaml
+++ b/pkgs/blast_repo/analysis_options.yaml
@@ -2,6 +2,5 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
-    strict-casts: true
     strict-inference: true
     strict-raw-types: true

--- a/pkgs/corpus/bin/api_usage.dart
+++ b/pkgs/corpus/bin/api_usage.dart
@@ -20,13 +20,13 @@ void main(List<String> args) async {
     exit(64);
   }
 
-  if (argResults.rest.length != 1 || argResults['help']) {
+  if (argResults.rest.length != 1 || argResults['help'] as bool) {
     _printUsage(argParser);
     exit(1);
   }
 
   final packageName = argResults.rest.first;
-  final packageLimit = int.tryParse(argResults['package-limit'])!;
+  final packageLimit = int.parse(argResults['package-limit'] as String);
   var showSrcReferences = argResults['show-src-references'] as bool;
 
   await analyzeUsage(

--- a/pkgs/corpus/bin/deps.dart
+++ b/pkgs/corpus/bin/deps.dart
@@ -27,13 +27,13 @@ void main(List<String> args) async {
     exit(64);
   }
 
-  if (argResults.rest.length != 1 || argResults['help']) {
+  if (argResults.rest.length != 1 || argResults['help'] as bool) {
     printUsage(argParser);
     exit(1);
   }
 
   final packageName = argResults.rest.first;
-  String? packageLimit = argResults['package-limit'];
+  var packageLimit = argResults['package-limit'] as String?;
   var excludeOld = argResults['exclude-old'] as bool;
 
   var log = Logger.standard();

--- a/pkgs/corpus/doc/package_collection.md
+++ b/pkgs/corpus/doc/package_collection.md
@@ -16,15 +16,15 @@ Stats for package:collection v1.17.0 pulled from 100 packages.
 
 | Library | Package references | % |
 | --- | ---: | ---: |
-| package:collection/collection.dart | 96 | 96% |
-| package:collection/src/iterable_extensions.dart | 1 | 1% |
+| package:collection/collection.dart | 95 | 95% |
+| package:collection/src/iterable_extensions.dart | 2 | 2% |
 
 ### Library references from libraries
 
 | Library | Library references | % |
 | --- | ---: | ---: |
-| package:collection/collection.dart | 289 | 79% |
-| package:collection/src/iterable_extensions.dart | 1 | 0% |
+| package:collection/collection.dart | 325 | 83% |
+| package:collection/src/iterable_extensions.dart | 2 | 1% |
 
 ## Class references
 
@@ -32,49 +32,51 @@ Stats for package:collection v1.17.0 pulled from 100 packages.
 
 | Class | Package references | % |
 | --- | ---: | ---: |
-| ListEquality | 22 | 22% |
+| ListEquality | 21 | 21% |
 | DeepCollectionEquality | 17 | 17% |
 | MapEquality | 8 | 8% |
-| _UnorderedEquality | 6 | 6% |
+| _UnorderedEquality | 5 | 5% |
+| IterableEquality | 5 | 5% |
 | SetEquality | 4 | 4% |
 | QueueList | 4 | 4% |
-| IterableEquality | 4 | 4% |
 | _DelegatingIterableBase | 3 | 3% |
-| UnmodifiableSetView | 3 | 3% |
-| DelegatingList | 2 | 2% |
-| UnorderedIterableEquality | 2 | 2% |
-| CanonicalizedMap | 2 | 2% |
+| DelegatingList | 3 | 3% |
 | DefaultEquality | 2 | 2% |
+| CanonicalizedMap | 2 | 2% |
 | PriorityQueue | 2 | 2% |
-| Equality | 2 | 2% |
+| UnmodifiableSetView | 2 | 2% |
 | UnmodifiableMapMixin | 1 | 1% |
+| UnorderedIterableEquality | 1 | 1% |
 | HeapPriorityQueue | 1 | 1% |
-| NonGrowableListMixin | 1 | 1% |
+| IterableZip | 1 | 1% |
 | CombinedMapView | 1 | 1% |
+| Equality | 1 | 1% |
+| NonGrowableListMixin | 1 | 1% |
 
 ### Class references from libraries
 
 | Class | Library references | % |
 | --- | ---: | ---: |
-| DeepCollectionEquality | 47 | 13% |
-| ListEquality | 42 | 12% |
-| MapEquality | 32 | 9% |
-| _DelegatingIterableBase | 21 | 6% |
-| Equality | 10 | 3% |
-| _UnorderedEquality | 9 | 2% |
+| DeepCollectionEquality | 48 | 12% |
+| ListEquality | 36 | 9% |
+| MapEquality | 32 | 8% |
+| _DelegatingIterableBase | 20 | 5% |
+| _UnorderedEquality | 8 | 2% |
 | SetEquality | 7 | 2% |
+| DelegatingList | 7 | 2% |
+| IterableEquality | 5 | 1% |
 | CanonicalizedMap | 5 | 1% |
-| DelegatingList | 4 | 1% |
 | QueueList | 4 | 1% |
-| IterableEquality | 4 | 1% |
-| UnmodifiableSetView | 4 | 1% |
 | UnmodifiableMapMixin | 2 | 1% |
-| UnorderedIterableEquality | 2 | 1% |
 | DefaultEquality | 2 | 1% |
 | PriorityQueue | 2 | 1% |
+| UnmodifiableSetView | 2 | 1% |
 | NonGrowableListMixin | 2 | 1% |
+| UnorderedIterableEquality | 1 | 0% |
 | HeapPriorityQueue | 1 | 0% |
+| IterableZip | 1 | 0% |
 | CombinedMapView | 1 | 0% |
+| Equality | 1 | 0% |
 
 ## Extension references
 
@@ -82,25 +84,27 @@ Stats for package:collection v1.17.0 pulled from 100 packages.
 
 | Extension | Package references | % |
 | --- | ---: | ---: |
-| IterableExtension | 49 | 49% |
-| ListExtensions | 11 | 11% |
-| IterableNullableExtension | 8 | 8% |
-| IterableComparableExtension | 3 | 3% |
+| IterableExtension | 51 | 51% |
+| ListExtensions | 13 | 13% |
+| IterableNullableExtension | 11 | 11% |
 | IterableNumberExtension | 3 | 3% |
 | IterableIntegerExtension | 2 | 2% |
+| IterableComparableExtension | 2 | 2% |
+| IterableIterableExtension | 1 | 1% |
 | IterableDoubleExtension | 1 | 1% |
 
 ### Extension references from libraries
 
 | Extension | Library references | % |
 | --- | ---: | ---: |
-| IterableExtension | 134 | 37% |
-| ListExtensions | 18 | 5% |
-| IterableNullableExtension | 14 | 4% |
-| IterableComparableExtension | 6 | 2% |
+| IterableExtension | 169 | 43% |
+| IterableNullableExtension | 24 | 6% |
+| ListExtensions | 23 | 6% |
 | IterableIntegerExtension | 4 | 1% |
+| IterableComparableExtension | 3 | 1% |
 | IterableNumberExtension | 3 | 1% |
 | IterableDoubleExtension | 2 | 1% |
+| IterableIterableExtension | 1 | 0% |
 
 ## Top-level symbols
 
@@ -109,130 +113,132 @@ Stats for package:collection v1.17.0 pulled from 100 packages.
 | Top-level symbol | Package references | % |
 | --- | ---: | ---: |
 | groupBy | 5 | 5% |
+| equalsIgnoreAsciiCase | 2 | 2% |
+| compareAsciiLowerCase | 2 | 2% |
+| compareAsciiLowerCaseNatural | 2 | 2% |
 | mergeSort | 2 | 2% |
-| equalsIgnoreAsciiCase | 1 | 1% |
 | minBy | 1 | 1% |
-| compareAsciiLowerCase | 1 | 1% |
+| compareNatural | 1 | 1% |
 | stronglyConnectedComponents | 1 | 1% |
 | lowerBound | 1 | 1% |
 | binarySearch | 1 | 1% |
 | insertionSort | 1 | 1% |
-| compareAsciiLowerCaseNatural | 1 | 1% |
 
 ### Top-level symbol references from libraries
 
 | Top-level symbol | Library references | % |
 | --- | ---: | ---: |
+| equalsIgnoreAsciiCase | 5 | 1% |
 | groupBy | 5 | 1% |
-| equalsIgnoreAsciiCase | 4 | 1% |
+| compareAsciiLowerCaseNatural | 3 | 1% |
+| compareAsciiLowerCase | 2 | 1% |
 | mergeSort | 2 | 1% |
 | minBy | 1 | 0% |
-| compareAsciiLowerCase | 1 | 0% |
+| compareNatural | 1 | 0% |
 | stronglyConnectedComponents | 1 | 0% |
 | lowerBound | 1 | 0% |
 | binarySearch | 1 | 0% |
 | insertionSort | 1 | 0% |
-| compareAsciiLowerCaseNatural | 1 | 0% |
 
 ## Corpus packages
 
-- provider v6.0.4
-- cloud_firestore v4.0.4
+- provider v6.0.5
+- cloud_firestore v4.3.1
 - equatable v2.0.5
-- get_it v7.2.0
-- flutter_riverpod v2.1.1
-- dart_code_metrics v5.0.1
-- freezed v2.2.1
-- built_value v8.4.2
+- flutter_riverpod v2.1.3
+- dart_code_metrics v5.4.0
+- freezed v2.3.2
 - shelf v1.4.0
+- built_value v8.4.3
+- simple_animations v5.0.0+3
+- mobx v2.1.3
+- flutter_map v3.1.0
 - flutter_form_builder v7.7.0
-- simple_animations v5.0.0+2
-- flutter_map v3.0.0
-- hooks_riverpod v2.1.1
-- xml v6.2.1
-- stacked v3.0.0
+- hooks_riverpod v2.1.3
+- intl_phone_number_input v0.7.2
+- xml v6.2.2
+- stacked v3.0.1
+- riverpod v2.1.3
+- multi_select_flutter v4.1.3
 - mocktail v0.3.0
-- riverpod v2.1.1
 - yaml v3.1.1
 - hydrated_bloc v9.0.0
-- adaptive_dialog v1.8.0+1
+- flutter_quill v6.2.1
 - http_parser v4.0.2
-- flutter_quill v6.1.4
-- sentry v6.14.0
-- objectbox v1.6.2
-- palette_generator v0.3.3+2
+- adaptive_dialog v1.8.0+1
 - network_info_plus v3.0.1
-- process_run v0.12.3+2
-- flutter_portal v1.1.2
-- country_picker v2.0.17
+- palette_generator v0.3.3+2
+- objectbox v1.7.0
+- sentry v6.18.2
+- country_picker v2.0.19
+- flutter_portal v1.1.3
+- process_run v0.12.5
+- pluto_grid v5.4.9
 - routemaster v1.0.1
-- web3dart v2.4.1
-- pluto_grid v5.4.0
-- pub_semver v2.1.2
-- code_builder v4.3.0
+- pub_semver v2.1.3
+- flex_color_picker v3.0.0
 - oauth2 v2.0.1
-- flex_color_picker v2.6.1
 - alice v0.3.2
 - telephony v0.2.0
-- storybook_flutter v0.11.2+2
-- intercom_flutter v7.5.0
-- built_value_generator v8.4.2
+- code_builder v4.4.0
+- dart_jsonwebtoken v2.6.2
+- built_value_generator v8.4.3
+- storybook_flutter v0.11.3
+- intercom_flutter v7.6.1
 - waterfall_flow v3.0.2
-- signalr_netcore v1.3.3
 - wiredash v1.5.0
-- dart_json_mapper v2.2.7
+- signalr_netcore v1.3.3
 - awesome_select v6.0.0
+- spider v4.2.0
+- dropdown_textfield v1.0.7
+- dart_json_mapper v2.2.7+5
+- dartdoc v6.1.5
+- jovial_svg v1.1.8
+- currency_picker v2.0.14
+- slang v3.7.0
 - graphs v2.2.0
-- puppeteer v2.17.0
-- functions_framework v0.4.1
-- dropdown_textfield v1.0.6
-- dart_ping v7.0.2
-- jovial_svg v1.1.6
-- rx_shared_preferences v3.0.0
-- currency_picker v2.0.12
-- grinder v0.9.2
-- slang v3.3.1
-- drag_select_grid_view v0.6.1
-- markdown_widget v1.3.0+2
-- linter v1.29.0
 - charts_painter v3.0.0
+- puppeteer v2.20.0
+- rx_shared_preferences v3.0.0
+- grinder v0.9.2
+- new_version_plus v0.0.8
+- drag_select_grid_view v0.6.1
+- functions_framework v0.4.1
 - flutter_slidable v2.0.0
-- go_router v5.1.5
-- yaru v0.4.3
 - split_view v3.2.1
-- flutter_cache_manager v3.3.0
-- scrollable_positioned_list v0.3.5
-- optional v6.1.0+1
-- encrypt v5.0.1
-- device_preview v1.1.0
-- introduction_screen v3.0.2
-- mobx v2.1.1
-- async v2.10.0
-- responsive_framework v0.2.0
-- mockito v5.3.2
+- go_router v6.0.1
+- melos v2.9.0
 - elementary v1.5.0
-- rive v0.9.1
-- freezed_annotation v2.2.0
-- intl_phone_number_input v0.7.1
-- new_version v0.3.1
+- scrollable_positioned_list v0.3.5
+- device_preview v1.1.0
+- introduction_screen v3.1.3
+- encrypt v5.0.1
+- async v2.10.0
 - form_bloc v0.30.0
-- flutter_multi_formatter v2.9.4
-- more v3.8.5
-- melos v2.8.0
-- syncfusion_flutter_datagrid v20.3.56
-- flame v1.4.0
-- loading_indicator v3.1.0
+- yaru v0.4.7
+- responsive_framework v0.2.0
+- rive v0.10.1
+- mockito v5.3.2
+- test v1.22.2
+- freezed_annotation v2.2.0
 - widget_mask v1.0.0+0
+- flame v1.5.0
+- syncfusion_flutter_datagrid v20.4.43
+- flutter_multi_formatter v2.10.1
+- easy_table v2.3.0
+- loading_indicator v3.1.0
+- floor v1.4.1
+- gpx v2.2.1
 - dartx v1.1.0
-- gql_dio_link v0.2.3
-- protobuf v2.1.0
 - flutter_layout_grid v2.0.1
+- protobuf v2.1.0
 - flinq v2.0.2
-- universal_io v2.0.4
+- more v3.9.5
+- dds v2.7.0
+- flutter_reactive_ble v5.0.3
 - back_button_interceptor v6.0.2
+- universal_io v2.0.4
+- bdd_widget_test v1.4.3
+- youtube_explode_dart v1.12.3
 - mapbox_gl v0.16.0
-- flutter_background_geolocation v4.8.3
-- gpx v2.2.0
 - markdown v6.0.1
-- cryptography v2.0.5
-- list_ext v1.0.6

--- a/pkgs/corpus/lib/api.dart
+++ b/pkgs/corpus/lib/api.dart
@@ -74,8 +74,8 @@ class ApiUsage {
         JsonDecoder().convert(file.readAsStringSync()) as Map<String, dynamic>;
     return ApiUsage(
       packageInfo,
-      References.fromJson(json['packages']),
-      References.fromJson(json['libraries']),
+      References.fromJson(json['packages'] as Map<String, dynamic>),
+      References.fromJson(json['libraries'] as Map<String, dynamic>),
     );
   }
 }
@@ -257,7 +257,7 @@ abstract class Entity {
   String toJson();
 
   static Entity fromJson(String json) {
-    List l = json.split(':');
+    var l = json.split(':');
     if (l.first == 'package') {
       return PackageEntity(l[1]);
     } else {
@@ -320,10 +320,11 @@ class References {
   factory References.fromJson(Map<String, dynamic> json) {
     var refs = References();
 
-    refs._libraryReferences.fromJson(json['library']);
-    refs._classReferences.fromJson(json['class']);
-    refs._extensionReferences.fromJson(json['extension']);
-    refs._topLevelReferences.fromJson(json['topLevel']);
+    refs._libraryReferences.fromJson(json['library'] as Map<String, dynamic>);
+    refs._classReferences.fromJson(json['class'] as Map<String, dynamic>);
+    refs._extensionReferences
+        .fromJson(json['extension'] as Map<String, dynamic>);
+    refs._topLevelReferences.fromJson(json['topLevel'] as Map<String, dynamic>);
 
     return refs;
   }
@@ -433,16 +434,16 @@ class EntityReferences {
     }
   }
 
-  void fromJson(Map json) {
+  void fromJson(Map<String, dynamic> json) {
     for (var key in json.keys) {
-      List entities = json[key];
+      var entities = (json[key] as List).cast<String>();
       for (var entity in entities) {
         add(key, Entity.fromJson(entity));
       }
     }
   }
 
-  Map toJson() {
+  Map<String, dynamic> toJson() {
     return {
       for (var entry in _references.entries)
         entry.key: entry.value.map((entity) => entity.toJson()).toList()

--- a/pkgs/corpus/lib/pub.dart
+++ b/pkgs/corpus/lib/pub.dart
@@ -185,24 +185,27 @@ class PackageInfo {
 
   PackageInfo.from(this.json);
 
-  String get name => json['name'];
-  String? get description => _pubspec['description'];
+  String get name => json['name'] as String;
+  String? get description => _pubspec['description'] as String?;
 
-  String? get repository => _pubspec['repository'];
-  String? get homepage => _pubspec['homepage'];
+  String? get repository => _pubspec['repository'] as String?;
+  String? get homepage => _pubspec['homepage'] as String?;
 
   String? get repo => repository ?? homepage;
-  Map<String, dynamic>? get environment => _pubspec['environment'];
-  String? get sdkConstraint => (environment ?? {})['sdk'];
+  Map<String, dynamic>? get environment =>
+      _pubspec['environment'] as Map<String, dynamic>?;
+  String? get sdkConstraint => (environment ?? {})['sdk'] as String?;
 
-  String get version => _latest['version'];
-  String get archiveUrl => _latest['archive_url'];
+  String get version => _latest['version'] as String;
+  String get archiveUrl => _latest['archive_url'] as String;
   DateTime get publishedDate => DateTime.parse(_published);
 
-  String get _published => _latest['published'];
+  String get _published => _latest['published'] as String;
 
-  late final Map<String, dynamic> _latest = json['latest'];
-  late final Map<String, dynamic> _pubspec = _latest['pubspec'];
+  late final Map<String, dynamic> _latest =
+      json['latest'] as Map<String, dynamic>;
+  late final Map<String, dynamic> _pubspec =
+      _latest['pubspec'] as Map<String, dynamic>;
 
   @override
   String toString() => '$name: $version';
@@ -211,7 +214,7 @@ class PackageInfo {
     if (_pubspec['dependencies'] is Map) {
       var deps = _pubspec['dependencies'] as Map;
       if (deps.containsKey(name)) {
-        String constraint = deps[name] ?? 'any';
+        var constraint = (deps[name] as String?) ?? 'any';
         if (constraint.isEmpty) {
           constraint = 'any';
         }
@@ -222,7 +225,7 @@ class PackageInfo {
     if (_pubspec['dev_dependencies'] is Map) {
       var deps = _pubspec['dev_dependencies'] as Map;
       if (deps.containsKey(name)) {
-        String constraint = deps[name] ?? 'any';
+        var constraint = (deps[name] as String?) ?? 'any';
         if (constraint.isEmpty) {
           constraint = 'any';
         }
@@ -266,9 +269,9 @@ class PackageOptions {
 
   PackageOptions.from(this.json);
 
-  bool get isDiscontinued => json['isDiscontinued'];
-  String? get replacedBy => json['replacedBy'];
-  bool get isUnlisted => json['isUnlisted'];
+  bool get isDiscontinued => json['isDiscontinued'] as bool;
+  String? get replacedBy => json['replacedBy'] as String?;
+  bool get isUnlisted => json['isUnlisted'] as bool;
 }
 
 class PackageScore {
@@ -282,8 +285,8 @@ class PackageScore {
 
   PackageScore.from(this.json);
 
-  int get grantedPoints => json['grantedPoints'];
-  int get maxPoints => json['maxPoints'];
-  int get likeCount => json['likeCount'];
-  double get popularityScore => json['popularityScore'];
+  int get grantedPoints => json['grantedPoints'] as int;
+  int get maxPoints => json['maxPoints'] as int;
+  int get likeCount => json['likeCount'] as int;
+  double get popularityScore => json['popularityScore'] as double;
 }

--- a/pkgs/corpus/lib/utils.dart
+++ b/pkgs/corpus/lib/utils.dart
@@ -31,11 +31,11 @@ Future<ProcessResult> runProcess(
     workingDirectory: workingDirectory,
   );
   if (result.exitCode != 0) {
-    String out = result.stdout;
+    var out = result.stdout as String;
     if (out.isNotEmpty) {
       logger == null ? print(out.trimRight()) : logger.stdout(out.trimRight());
     }
-    out = result.stderr;
+    out = result.stderr as String;
     if (out.isNotEmpty) {
       logger == null ? print(out.trimRight()) : logger.stderr(out.trimRight());
     }

--- a/pkgs/corpus/test/api_test.dart
+++ b/pkgs/corpus/test/api_test.dart
@@ -20,9 +20,10 @@ void main() {
       var json =
           JsonDecoder().convert(_sampleUsageJson) as Map<String, dynamic>;
       sampleUsage = ApiUsage(
-        PackageInfo.from(JsonDecoder().convert(_packageInfoJson)),
-        References.fromJson(json['packages']),
-        References.fromJson(json['libraries']),
+        PackageInfo.from(
+            JsonDecoder().convert(_packageInfoJson) as Map<String, dynamic>),
+        References.fromJson(json['packages'] as Map<String, dynamic>),
+        References.fromJson(json['libraries'] as Map<String, dynamic>),
       );
     });
 
@@ -41,7 +42,10 @@ void main() {
       sampleUsage.toFile(tempFile);
 
       var result = ApiUsage.fromFile(
-          PackageInfo.from(JsonDecoder().convert(_packageInfoJson)), tempFile);
+        PackageInfo.from(
+            JsonDecoder().convert(_packageInfoJson) as Map<String, dynamic>),
+        tempFile,
+      );
 
       checkThat(result).isNotNull();
 

--- a/pkgs/corpus/test/data/dart_library_references.dart
+++ b/pkgs/corpus/test/data/dart_library_references.dart
@@ -11,6 +11,6 @@ void main() {
   map['three'] = 3;
   print(map);
 
-  dynamic local;
+  var local = Queue();
   Queue.castFrom(local);
 }

--- a/pkgs/corpus/test/pub_test.dart
+++ b/pkgs/corpus/test/pub_test.dart
@@ -13,7 +13,8 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('PackageInfo', () {
     test('parse pub.dev results', () {
-      var packageInfo = PackageInfo.from(jsonDecode(_pubSampleData));
+      var packageInfo =
+          PackageInfo.from(jsonDecode(_pubSampleData) as Map<String, dynamic>);
 
       checkThat(packageInfo.name).equals('usage');
       checkThat(packageInfo.version).equals('4.0.2');

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-dev.1
+
+- Turn on `strict-casts: true`.
+
 ## 0.1.0-dev
 
 - Initial version.

--- a/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
@@ -15,6 +15,10 @@
 
 include: package:lints/recommended.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+
 linter:
   rules:
     # consistency

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flutter_team_lints
 description: An analysis rule set used by the Dart and Flutter teams.
-version: 0.1.0-dev
+version: 0.1.0-dev.1
 repository: https://github.com/dart-lang/ecosystem/tree/main/packages/dart_flutter_team_lints
 
 environment:


### PR DESCRIPTION
- add `strict-casts: true` to dart_flutter_team_lints
- update `package:corpus` for the new analysis setting
- re-generate the sample usage histogram at `corpus/doc/package_collection.md` to verify no runtime issues were introduced
