### PR TITLE
add an auto-publish configuration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+# A CI configuration to auto-publish pub packages.
+
+name: Publish
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    tags: [ '[a-zA-Z_]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+
+jobs:
+  publish:
+    if: github.repository_owner == 'dart-lang'
+    uses: devoncarew/firehose/.github/workflows/publish.yaml@main

--- a/README.md
+++ b/README.md
@@ -11,3 +11,25 @@ This repository is home to general Dart Ecosystem tools and packages.
 | [blast_repo](pkgs/blast_repo/) | A tool to bulk validate and fix GitHub repos. |  |
 | [corpus](pkgs/corpus/) | A tool to calculate the API usage for a package. |  |
 | [dart_flutter_team_lints](pkgs/dart_flutter_team_lints/) | An analysis rule set used by the Dart and Flutter teams. | [![pub package](https://img.shields.io/pub/v/dart_flutter_team_lints.svg)](https://pub.dev/packages/dart_flutter_team_lints) |
+
+## Contributions, PRs, and publishing
+
+When contributing to this repo:
+
+- if the package version is a stable semver version (`x.y.z`), the latest
+  changes have been published to pub. Please add a new changelog section for
+  your change, rev the service portion of the version, append `-dev`, and update
+  the pubspec version to agree with the new version
+- if the package version ends in `-dev`, the latest changes are unpublished;
+  please add a new changelog entry for your change in the most recent section.
+  When we decide to publish the latest changes we'll drop the `-dev` suffix
+  from the package version
+- for PRs, the `Publish` bot will perform basic validation of the info in the
+  pubspec.yaml and CHANGELOG.md files
+- when the PR is merged into the main branch, if the change includes reving to
+  a new stable version, a repo maintainer will tag that commit with the pubspec
+  version (e.g., `v1.2.3`); that tag event will trigger the `Publish` bot to
+  publish a new version of the package to pub.dev
+
+For additional information about contributing, see our
+[contributing](CONTRIBUTING.md) page.

--- a/pkgs/corpus/pubspec.yaml
+++ b/pkgs/corpus/pubspec.yaml
@@ -1,7 +1,5 @@
 name: corpus
 description: A tool to calculate the API usage for a package.
-repository: https://github.com/dart-lang/ecosystem
-
 publish_to: none
 
 environment:

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0-dev.1
+## 0.1.0
 
 - Turn on `strict-casts: true`.
 

--- a/pkgs/dart_flutter_team_lints/README.md
+++ b/pkgs/dart_flutter_team_lints/README.md
@@ -1,3 +1,4 @@
+![pub package](https://img.shields.io/pub/v/dart_flutter_team_lints.svg)](https://pub.dev/packages/dart_flutter_team_lints)
 
 ## What is this?
 

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_flutter_team_lints
 description: An analysis rule set used by the Dart and Flutter teams.
-version: 0.1.0-dev.1
-repository: https://github.com/dart-lang/ecosystem/tree/main/packages/dart_flutter_team_lints
+version: 0.1.0
+repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
- add an auto-publish configuration
- prep `dart_flutter_team_lints` for publishing (it's first non-dev publish, though note that it's still unlisted)
- update readme and contributing info
- (and make sure the two other packages in here have `publish_to: none` set)
