### PR TITLE
determine the default branch for the auto-publish fix

### DIFF
--- a/pkgs/blast_repo/lib/src/exact_file_tweak.dart
+++ b/pkgs/blast_repo/lib/src/exact_file_tweak.dart
@@ -45,7 +45,7 @@ abstract class ExactFileTweak extends RepoTweak {
   final String filePath;
   final Set<String> alternateFilePaths;
 
-  String expectedContent(String repoSlug);
+  String expectedContent(Directory checkout, String repoSlug);
 
   @override
   FutureOr<FixResult> fix(Directory checkout, String repoSlug) {
@@ -53,7 +53,7 @@ abstract class ExactFileTweak extends RepoTweak {
 
     var fixResults = <String>[];
 
-    final newContent = expectedContent(repoSlug);
+    final newContent = expectedContent(checkout, repoSlug);
     if (!file.existsSync()) {
       file.writeAsStringSync(newContent);
       fixResults.add('$filePath has been created.');

--- a/pkgs/blast_repo/lib/src/tweaks/auto_publish_tweak.dart
+++ b/pkgs/blast_repo/lib/src/tweaks/auto_publish_tweak.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import '../exact_file_tweak.dart';
+import '../utils.dart';
 
 final _instance = AutoPublishTweak._();
 
@@ -25,11 +26,15 @@ class AutoPublishTweak extends ExactFileTweak {
   bool get stable => false;
 
   @override
-  String expectedContent(String repoSlug) {
+  String expectedContent(Directory checkout, String repoSlug) {
     final org = repoSlug.split('/').first;
+    final branch = gitDefaultBranch(checkout) ?? 'main';
 
-    // Substitute the org value for the pattern '{org}'.
-    return publishContents.replaceAll('{org}', org);
+    // Substitute the org value for the pattern '{org}' and the default branch
+    // value for '{branch}'.
+    return publishContents
+        .replaceAll('{org}', org)
+        .replaceAll('{branch}', branch);
   }
 
   @override
@@ -62,13 +67,13 @@ name: Publish
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ {branch} ]
   push:
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:
-    if: github.repository_owner == '{org}'
+    if: ${{ github.repository_owner == {org} }}
     uses: devoncarew/firehose/.github/workflows/publish.yaml@main
 ''';
 

--- a/pkgs/blast_repo/lib/src/tweaks/no_reponse_tweak.dart
+++ b/pkgs/blast_repo/lib/src/tweaks/no_reponse_tweak.dart
@@ -27,7 +27,8 @@ class NoResponseTweak extends ExactFileTweak {
   bool get stable => false;
 
   @override
-  String expectedContent(String repoSlug) => _noResponseContent;
+  String expectedContent(Directory checkout, String repoSlug) =>
+      _noResponseContent;
 
   @override
   FutureOr<FixResult> fix(Directory checkout, String repoSlug) {

--- a/pkgs/blast_repo/lib/src/utils.dart
+++ b/pkgs/blast_repo/lib/src/utils.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:git/git.dart';
 import 'package:io/ansi.dart';
+import 'package:path/path.dart' as p;
 
 const packageName = 'blast_repo';
 
@@ -97,3 +98,21 @@ String _fileDate() => DateTime.now()
     .split(_dateSeparators)
     .take(5)
     .join('_');
+
+/// This makes a best effort to find the default branch of the given repo.
+String? gitDefaultBranch(Directory repoDir) {
+  const branchNames = ['main', 'master'];
+
+  var configFile = File(p.join(repoDir.path, '.git', 'config'));
+  if (!configFile.existsSync()) return null;
+
+  var lines = configFile.readAsLinesSync();
+
+  for (var name in branchNames) {
+    if (lines.contains('[branch "$name"]')) {
+      return name;
+    }
+  }
+
+  return null;
+}

--- a/pkgs/blast_repo/lib/src/utils.dart
+++ b/pkgs/blast_repo/lib/src/utils.dart
@@ -101,7 +101,7 @@ String _fileDate() => DateTime.now()
 
 /// This makes a best effort to find the default branch of the given repo.
 String? gitDefaultBranch(Directory repoDir) {
-  const branchNames = ['main', 'master'];
+  const branchNames = {'main', 'master'};
 
   var configFile = File(p.join(repoDir.path, '.git', 'config'));
   if (!configFile.existsSync()) return null;

--- a/pkgs/blast_repo/test/utils_test.dart
+++ b/pkgs/blast_repo/test/utils_test.dart
@@ -8,9 +8,10 @@ import 'package:blast_repo/src/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // We skip this test on github actions as that typically does a shallow clone.
   test('gitDefaultBranch', () {
     final result = gitDefaultBranch(io.Directory.current.parent.parent);
 
     expect(result, 'main');
-  });
+  }, skip: io.Platform.environment['GITHUB_ACTIONS'] == 'true');
 }

--- a/pkgs/blast_repo/test/utils_test.dart
+++ b/pkgs/blast_repo/test/utils_test.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:blast_repo/src/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('gitDefaultBranch', () {
+    final result = gitDefaultBranch(io.Directory.current.parent.parent);
+
+    expect(result, 'main');
+  });
+}

--- a/pkgs/dart_flutter_team_lints/README.md
+++ b/pkgs/dart_flutter_team_lints/README.md
@@ -1,4 +1,4 @@
-![pub package](https://img.shields.io/pub/v/dart_flutter_team_lints.svg)](https://pub.dev/packages/dart_flutter_team_lints)
+[![pub package](https://img.shields.io/pub/v/dart_flutter_team_lints.svg)](https://pub.dev/packages/dart_flutter_team_lints)
 
 ## What is this?
 


### PR DESCRIPTION
- determine the default branch for the auto-publish fix

We were defaulting to `branches: [ main ]` for this fix (which wouldn't run the workflow), but 80% of the dart-lang repos are still on master.
