### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github/workflows/dart.yml linguist-generated=true


### PR DESCRIPTION
- indicate that PRs shouldn't show diffs of the mono_repo generated workflow file by default
