### PR TITLE
call fewer github apis in the tests

### DIFF
--- a/pkgs/blast_repo/test/github_action_test.dart
+++ b/pkgs/blast_repo/test/github_action_test.dart
@@ -53,21 +53,20 @@ void main() {
         addTearDown(resolver.close);
       });
 
-      for (var action in actions.entries) {
-        final result = ActionVersion.parse(action.key);
-        test(
-          '"${action.key}"',
-          skip:
-              result.path == null ? null : 'Cannot handle paths at the moment.',
-          () async {
-            final tag = await resolver.resolve(result);
-            // version or branch resolved
-            expect(tag.version?.toString() ?? tag.branch, isNotEmpty);
-            // sha resolved
-            expect(tag.sha, isNotEmpty);
-          },
-        );
-      }
+      final action = actions.entries.first;
+      final result = ActionVersion.parse(action.key);
+
+      test(
+        '"${action.key}"',
+        skip: result.path == null ? null : 'Cannot handle paths at the moment.',
+        () async {
+          final tag = await resolver.resolve(result);
+          // version or branch resolved
+          expect(tag.version?.toString() ?? tag.branch, isNotEmpty);
+          // sha resolved
+          expect(tag.sha, isNotEmpty);
+        },
+      );
     });
 
     group('latest fun', () {
@@ -78,15 +77,12 @@ void main() {
         addTearDown(resolver.close);
       });
 
-      final repos =
-          actions.keys.map(ActionVersion.parse).map((e) => e.fullRepo).toSet();
+      final repo = ActionVersion.parse(actions.keys.first).fullRepo;
 
-      for (var repo in repos) {
-        test('"$repo"', () async {
-          // TODO(kevmoo): do more than just run - but better than nothing
-          await resolver.latestStable(repo);
-        });
-      }
+      test('"$repo"', () async {
+        // TODO(kevmoo): do more than just run - but better than nothing
+        await resolver.latestStable(repo);
+      });
     });
   });
 }


### PR DESCRIPTION
- call fewer github apis in the tests

The CI's been pretty flakey lately due to timeouts calling the github APIs (see https://github.com/dart-lang/ecosystem/actions/runs/3991826801/jobs/6847080483). This doesn't fix the issue but does make it much less likely (2 api calls instead of 20).
