### PR TITLE
use pubspec_overrides.yaml files

### DIFF
--- a/pkgs/blast_repo/pubspec.yaml
+++ b/pkgs/blast_repo/pubspec.yaml
@@ -25,7 +25,3 @@ dev_dependencies:
 
 executables:
   blast_repo:
-
-dependency_overrides:
-  dart_flutter_team_lints:
-    path: ../dart_flutter_team_lints

--- a/pkgs/blast_repo/pubspec_overrides.yaml
+++ b/pkgs/blast_repo/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  dart_flutter_team_lints:
+    path: ../dart_flutter_team_lints

--- a/pkgs/corpus/pubspec.yaml
+++ b/pkgs/corpus/pubspec.yaml
@@ -23,7 +23,3 @@ dev_dependencies:
   dart_flutter_team_lints: ^0.1.0
   test: ^1.22.0
   test_descriptor: ^2.0.0
-
-dependency_overrides:
-  dart_flutter_team_lints:
-    path: ../dart_flutter_team_lints

--- a/pkgs/corpus/pubspec_overrides.yaml
+++ b/pkgs/corpus/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  dart_flutter_team_lints:
+    path: ../dart_flutter_team_lints

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -20,7 +20,3 @@ dependencies:
 dev_dependencies:
   dart_flutter_team_lints: ^0.1.0
   test: ^1.21.0
-
-dependency_overrides:
-  dart_flutter_team_lints:
-    path: ../dart_flutter_team_lints

--- a/pkgs/firehose/pubspec_overrides.yaml
+++ b/pkgs/firehose/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  dart_flutter_team_lints:
+    path: ../dart_flutter_team_lints


### PR DESCRIPTION
- switch from using `dependency_overrides` in pubspec files to using separate `pubspec_overrides.yaml` files

These files only act on pub get and pub upgrade, and will not take effect for things like pub publish.
