### PR TITLE
add more lints to package:dart_flutter_team_lints

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,48 +39,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; Dart 2.17.0; PKG: pkgs/firehose; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.19.0; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/firehose;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/firehose
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_firehose_pub_upgrade
-        name: pkgs/firehose; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/firehose
-      - name: "pkgs/firehose; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.pkgs_firehose_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/firehose
-    needs:
-      - job_001
-  job_003:
-    name: "analyze_and_format; Dart 2.19.0; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints; `dart analyze --fatal-infos .`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints;commands:analyze"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose
             os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -109,9 +77,18 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/dart_flutter_team_lints
+      - id: pkgs_firehose_pub_upgrade
+        name: pkgs/firehose; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/firehose
+      - name: "pkgs/firehose; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_firehose_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/firehose
     needs:
       - job_001
-  job_004:
+  job_003:
     name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -161,7 +138,7 @@ jobs:
         working-directory: pkgs/firehose
     needs:
       - job_001
-  job_005:
+  job_004:
     name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
@@ -211,43 +188,7 @@ jobs:
         working-directory: pkgs/firehose
     needs:
       - job_001
-  job_006:
-    name: "unit_test; Dart 2.17.0; PKG: pkgs/firehose; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/firehose;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/firehose
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_firehose_pub_upgrade
-        name: pkgs/firehose; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/firehose
-      - name: pkgs/firehose; dart test
-        run: dart test
-        if: "always() && steps.pkgs_firehose_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/firehose
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-  job_007:
+  job_005:
     name: "unit_test; Dart 2.19.0; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -282,8 +223,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-      - job_005
-  job_008:
+  job_006:
     name: "unit_test; Dart 2.19.0; PKG: pkgs/dart_flutter_team_lints; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -318,8 +258,42 @@ jobs:
       - job_002
       - job_003
       - job_004
-      - job_005
-  job_009:
+  job_007:
+    name: "unit_test; Dart 2.19.0; PKG: pkgs/firehose; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/firehose;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/firehose
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: "2.19.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_firehose_pub_upgrade
+        name: pkgs/firehose; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/firehose
+      - name: pkgs/firehose; dart test
+        run: dart test
+        if: "always() && steps.pkgs_firehose_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/firehose
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_008:
     name: "unit_test; Dart dev; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -354,8 +328,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-      - job_005
-  job_010:
+  job_009:
     name: "unit_test; Dart dev; PKG: pkgs/dart_flutter_team_lints; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -390,8 +363,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-      - job_005
-  job_011:
+  job_010:
     name: "unit_test; Dart dev; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -426,8 +398,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-      - job_005
-  job_012:
+  job_011:
     name: "analyze_format; Dart dev; PKG: pkgs/blast_repo; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -472,8 +443,7 @@ jobs:
       - job_008
       - job_009
       - job_010
-      - job_011
-  job_013:
+  job_012:
     name: "test; Dart dev; PKG: pkgs/blast_repo; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -515,4 +485,3 @@ jobs:
       - job_009
       - job_010
       - job_011
-      - job_012

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,16 +39,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; Dart 2.17.0; PKGS: pkgs/dart_flutter_team_lints, pkgs/firehose; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.17.0; PKG: pkgs/firehose; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/dart_flutter_team_lints-pkgs/firehose;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/firehose;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/dart_flutter_team_lints-pkgs/firehose
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/firehose
             os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -59,15 +59,6 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_dart_flutter_team_lints_pub_upgrade
-        name: pkgs/dart_flutter_team_lints; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
-      - name: "pkgs/dart_flutter_team_lints; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
       - id: pkgs_firehose_pub_upgrade
         name: pkgs/firehose; dart pub upgrade
         run: dart pub upgrade
@@ -80,23 +71,23 @@ jobs:
     needs:
       - job_001
   job_003:
-    name: "analyze_and_format; Dart 2.18.0; PKG: pkgs/corpus; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.19.0; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:pkgs/corpus;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:pkgs/corpus
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
         with:
-          sdk: "2.18.0"
+          sdk: "2.19.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
@@ -109,6 +100,15 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_corpus_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/corpus
+      - id: pkgs_dart_flutter_team_lints_pub_upgrade
+        name: pkgs/dart_flutter_team_lints; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
+      - name: "pkgs/dart_flutter_team_lints; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
     needs:
       - job_001
   job_004:
@@ -212,42 +212,6 @@ jobs:
     needs:
       - job_001
   job_006:
-    name: "unit_test; Dart 2.17.0; PKG: pkgs/dart_flutter_team_lints; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/dart_flutter_team_lints;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:pkgs/dart_flutter_team_lints
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_dart_flutter_team_lints_pub_upgrade
-        name: pkgs/dart_flutter_team_lints; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
-      - name: pkgs/dart_flutter_team_lints; dart test
-        run: dart test
-        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-  job_007:
     name: "unit_test; Dart 2.17.0; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -283,24 +247,24 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_008:
-    name: "unit_test; Dart 2.18.0; PKG: pkgs/corpus; `dart test`"
+  job_007:
+    name: "unit_test; Dart 2.19.0; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:pkgs/corpus;commands:test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:pkgs/corpus
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/corpus
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
         with:
-          sdk: "2.18.0"
+          sdk: "2.19.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
@@ -313,6 +277,42 @@ jobs:
         run: dart test
         if: "always() && steps.pkgs_corpus_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/corpus
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_008:
+    name: "unit_test; Dart 2.19.0; PKG: pkgs/dart_flutter_team_lints; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/dart_flutter_team_lints;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/dart_flutter_team_lints
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: "2.19.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_dart_flutter_team_lints_pub_upgrade
+        name: pkgs/dart_flutter_team_lints; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
+      - name: pkgs/dart_flutter_team_lints; dart test
+        run: dart test
+        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
     needs:
       - job_001
       - job_002

--- a/pkgs/blast_repo/pubspec.yaml
+++ b/pkgs/blast_repo/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool to bulk validate and fix GitHub repos.
 publish_to: none
 
 environment:
-  sdk: ^2.18.0
+  sdk: ^2.19.0
 
 dependencies:
   args: ^2.3.1

--- a/pkgs/corpus/bin/deps.dart
+++ b/pkgs/corpus/bin/deps.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Outputs information in CSV format for all the dependents of a given package.
+library;
 
 import 'dart:io';
 

--- a/pkgs/corpus/pubspec.yaml
+++ b/pkgs/corpus/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool to calculate the API usage for a package.
 publish_to: none
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   analyzer: ^5.0.0

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.0
+
+- Added `collection_methods_unrelated_type`.
+- Added `combinators_ordering`.
+- Added `dangling_library_doc_comments`.
+- Added `implicit_call_tearoffs`.
+- Added `library_annotations`.
+- Added `unnecessary_library_directive`.
+- Added `unreachable_from_main`.
+- Added `use_string_in_part_of_directives`.
+
 ## 0.1.0
 
 - Turn on `strict-casts: true`.

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `unnecessary_library_directive`.
 - Added `unreachable_from_main`.
 - Added `use_string_in_part_of_directives`.
+- Require Dart `2.19.0`.
 
 ## 0.1.0
 

--- a/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
@@ -26,10 +26,12 @@ linter:
     - avoid_shadowing_type_parameters
     - avoid_types_as_parameter_names
     - camel_case_extensions
+    - combinators_ordering
     - curly_braces_in_flow_control_structures
     - directives_ordering
     - empty_catches
     - file_names
+    - library_annotations
     - lines_longer_than_80_chars
     - omit_local_variable_types
     - prefer_asserts_in_initializer_lists
@@ -39,20 +41,26 @@ linter:
     - prefer_typing_uninitialized_variables
     - sort_pub_dependencies
     - unnecessary_lambdas
+    - unnecessary_library_directive
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_statements
     - use_is_even_rather_than_modulo
+    - use_string_in_part_of_directives
 
     # correctness
     - always_declare_return_types
     - avoid_catching_errors
     - avoid_dynamic_calls
     - await_only_futures
+    - collection_methods_unrelated_type
+    - dangling_library_doc_comments
     - hash_and_equals
+    - implicit_call_tearoffs
     - no_duplicate_case_values
     - only_throw_errors
     - throw_in_finally
     - type_annotate_public_apis
     - unawaited_futures
+    - unreachable_from_main
     - unrelated_type_equality_checks

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flutter_team_lints
 description: An analysis rule set used by the Dart and Flutter teams.
-version: 0.1.0
+version: 1.0.0
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 
 environment:
@@ -10,5 +10,6 @@ dependencies:
   lints: ^2.0.0
 
 dev_dependencies:
+  checks: ^0.2.0
   test: ^1.0.0
   yaml: ^3.0.0

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   lints: ^2.0.0

--- a/pkgs/dart_flutter_team_lints/test/validate_test.dart
+++ b/pkgs/dart_flutter_team_lints/test/validate_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:checks/checks.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
@@ -16,16 +17,16 @@ void main() {
 
   test('well-formed', () {
     var result = yaml.loadYaml(content);
-    expect(result, isMap);
+    check(result).isA<Map>();
   });
 
   test('references recommended', () {
     var result = yaml.loadYaml(content) as yaml.YamlMap;
-    expect(result['include'], equals('package:lints/recommended.yaml'));
+    check(result['include']).equals('package:lints/recommended.yaml');
   });
 
   test('defines linter rules', () {
     var result = yaml.loadYaml(content) as yaml.YamlMap;
-    expect((result['linter'] as Map)['rules'], isNotEmpty);
+    check((result['linter'] as Map)['rules'] as List).isNotEmpty();
   });
 }

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.14-dev
+
+- Require Dart `2.19.0`.
+
 ## 0.3.13
 
 - Added the ability to specify the version of the SDK to use for publishing.

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,10 +1,10 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.13
+version: 0.3.14-dev
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 executables:
   firehose: firehose


### PR DESCRIPTION
- add more lints to package:dart_flutter_team_lints
- fix https://github.com/dart-lang/ecosystem/issues/47

@natebosch, wdyt about the version bump? There are probably two things here:

- moving from the `0.x.0` versions to `x.0.0` versions; given that this is just used in our own repos I think there's no reason to not switch to using 1.0+ major versions

- when we add new lints, does this happen in the current major version or in the next one? new lints will likely cause CIs to fail as the analysis gets more restrictive. Doing lint additions in a new major version would mean CIs would avoid async failures.

However, from a pragmatic perspective, it's expensive to send `n` PRs to our various repos to bump deps from `^0.1.0` to `^0.2.0`. We could just upgrade failing CIs as they occur, or pin them to something like `>=1.3.0 <1.4.0` if they were not yet ready to address the new lints.
