### PR TITLE
contribute a repo query tool and scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/repo_query.md
+++ b/.github/ISSUE_TEMPLATE/repo_query.md
@@ -1,0 +1,5 @@
+---
+name: "package:repo_query"
+about: "Create a bug or file a feature request against package:repo_query."
+labels: "package:repo_query"
+---

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,3 +14,6 @@
 
 'package:firehose':
   - pkgs/firehose/**/*
+
+'package:repo_query':
+  - pkgs/repo_query/**/*

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -321,41 +321,6 @@ jobs:
       - job_003
       - job_004
   job_008:
-    name: "unit_test; Dart 2.19.0; PKG: pkgs/repo_query; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/repo_query;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/repo_query
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: "2.19.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_repo_query_pub_upgrade
-        name: pkgs/repo_query; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/repo_query
-      - name: pkgs/repo_query; dart test
-        run: dart test
-        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/repo_query
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_009:
     name: "unit_test; Dart dev; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -390,7 +355,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_010:
+  job_009:
     name: "unit_test; Dart dev; PKG: pkgs/dart_flutter_team_lints; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -425,7 +390,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
+  job_010:
     name: "unit_test; Dart dev; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -460,42 +425,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_012:
-    name: "unit_test; Dart dev; PKG: pkgs/repo_query; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/repo_query;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/repo_query
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: dev
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_repo_query_pub_upgrade
-        name: pkgs/repo_query; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/repo_query
-      - name: pkgs/repo_query; dart test
-        run: dart test
-        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/repo_query
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_013:
+  job_011:
     name: "analyze_format; Dart dev; PKG: pkgs/blast_repo; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -540,9 +470,7 @@ jobs:
       - job_008
       - job_009
       - job_010
-      - job_011
-      - job_012
-  job_014:
+  job_012:
     name: "test; Dart dev; PKG: pkgs/blast_repo; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -584,5 +512,3 @@ jobs:
       - job_009
       - job_010
       - job_011
-      - job_012
-      - job_013

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -112,16 +112,48 @@ jobs:
     needs:
       - job_001
   job_004:
-    name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.19.0; PKG: pkgs/repo_query; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/repo_query;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/repo_query
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: "2.19.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_repo_query_pub_upgrade
+        name: pkgs/repo_query; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+      - name: "pkgs/repo_query; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+    needs:
+      - job_001
+  job_005:
+    name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose, pkgs/repo_query; `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose-pkgs/repo_query;commands:analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose-pkgs/repo_query
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -159,19 +191,28 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_firehose_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/firehose
+      - id: pkgs_repo_query_pub_upgrade
+        name: pkgs/repo_query; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+      - name: "pkgs/repo_query; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/repo_query
     needs:
       - job_001
-  job_005:
-    name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose; `dart format --output=none --set-exit-if-changed .`"
+  job_006:
+    name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose, pkgs/repo_query; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose;commands:format"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose-pkgs/repo_query;commands:format"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose-pkgs/repo_query
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -209,9 +250,18 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.pkgs_firehose_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/firehose
+      - id: pkgs_repo_query_pub_upgrade
+        name: pkgs/repo_query; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+      - name: "pkgs/repo_query; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/repo_query
     needs:
       - job_001
-  job_006:
+  job_007:
     name: "unit_test; Dart 2.17.0; PKG: pkgs/dart_flutter_team_lints; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -247,7 +297,8 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_007:
+      - job_006
+  job_008:
     name: "unit_test; Dart 2.17.0; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -283,7 +334,8 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_008:
+      - job_006
+  job_009:
     name: "unit_test; Dart 2.18.0; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -319,7 +371,45 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_009:
+      - job_006
+  job_010:
+    name: "unit_test; Dart 2.19.0; PKG: pkgs/repo_query; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/repo_query;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0;packages:pkgs/repo_query
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.19.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: "2.19.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_repo_query_pub_upgrade
+        name: pkgs/repo_query; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+      - name: pkgs/repo_query; dart test
+        run: dart test
+        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_011:
     name: "unit_test; Dart dev; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -355,7 +445,8 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_010:
+      - job_006
+  job_012:
     name: "unit_test; Dart dev; PKG: pkgs/dart_flutter_team_lints; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -391,7 +482,8 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_011:
+      - job_006
+  job_013:
     name: "unit_test; Dart dev; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -427,7 +519,45 @@ jobs:
       - job_003
       - job_004
       - job_005
-  job_012:
+      - job_006
+  job_014:
+    name: "unit_test; Dart dev; PKG: pkgs/repo_query; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/repo_query;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/repo_query
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_repo_query_pub_upgrade
+        name: pkgs/repo_query; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+      - name: pkgs/repo_query; dart test
+        run: dart test
+        if: "always() && steps.pkgs_repo_query_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/repo_query
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_015:
     name: "analyze_format; Dart dev; PKG: pkgs/blast_repo; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -473,7 +603,10 @@ jobs:
       - job_009
       - job_010
       - job_011
-  job_013:
+      - job_012
+      - job_013
+      - job_014
+  job_016:
     name: "test; Dart dev; PKG: pkgs/blast_repo; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -516,3 +649,6 @@ jobs:
       - job_010
       - job_011
       - job_012
+      - job_013
+      - job_014
+      - job_015

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository is home to general Dart Ecosystem tools and packages.
 | [corpus](pkgs/corpus/) | A tool to calculate the API usage for a package. |  |
 | [dart_flutter_team_lints](pkgs/dart_flutter_team_lints/) | An analysis rule set used by the Dart and Flutter teams. | [![pub package](https://img.shields.io/pub/v/dart_flutter_team_lints.svg)](https://pub.dev/packages/dart_flutter_team_lints) |
 | [firehose](pkgs/firehose/) | A tool to automate publishing of Pub packages from GitHub actions. | [![pub package](https://img.shields.io/pub/v/firehose.svg)](https://pub.dev/packages/firehose) |
+| [repo_query](pkgs/repo_query/) | Miscellaneous issue, repo, and PR query tools. |  |
 
 ## Publishing automation
 

--- a/pkgs/repo_query/README.md
+++ b/pkgs/repo_query/README.md
@@ -1,0 +1,18 @@
+Various and miscellaneous commands to query dart-lang github repos.
+
+## Usage
+
+```
+Usage: dart bin/report.dart <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+  branches   Show the default branch names of Dart and Flutter repos.
+  labels     Report on the various labels in use by dart-lang repos.
+  links      List useful GitHub query urls.
+  weekly     Run a week-based report on repo status and activity.
+
+Run "report help <command>" for more information about a command.
+```

--- a/pkgs/repo_query/analysis_options.yaml
+++ b/pkgs/repo_query/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/repo_query/bin/report.dart
+++ b/pkgs/repo_query/bin/report.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:repo_query/src/common.dart';
+
+void main(List<String> args) async {
+  final runner = ReportCommandRunner();
+  exit(await runner.run(args) ?? 0);
+}

--- a/pkgs/repo_query/lib/branches.dart
+++ b/pkgs/repo_query/lib/branches.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'src/common.dart';
+
+class BranchesCommand extends ReportCommand {
+  BranchesCommand()
+      : super('branches',
+            'Show the default branch names of Dart and Flutter repos.');
+
+  @override
+  Future<int> run() async {
+    print('Repository, Default branch, Stars');
+
+    for (var org in ['dart-lang', 'flutter']) {
+      var repos = getReposForOrg(org);
+
+      await repos.forEach((repo) {
+        print('$org/${repo.name}, ${repo.defaultBranch}, '
+            '${repo.stargazersCount}');
+      });
+    }
+
+    return 0;
+  }
+}

--- a/pkgs/repo_query/lib/branches.dart
+++ b/pkgs/repo_query/lib/branches.dart
@@ -14,12 +14,12 @@ class BranchesCommand extends ReportCommand {
     print('Repository, Default branch, Stars');
 
     for (var org in ['dart-lang', 'flutter']) {
-      var repos = getReposForOrg(org);
+      var repos = await getReposForOrg(org);
 
-      await repos.forEach((repo) {
+      for (var repo in repos) {
         print('$org/${repo.name}, ${repo.defaultBranch}, '
             '${repo.stargazersCount}');
-      });
+      }
     }
 
     return 0;

--- a/pkgs/repo_query/lib/labels.dart
+++ b/pkgs/repo_query/lib/labels.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:math';
+
+import 'src/common.dart';
+
+class LabelsCommand extends ReportCommand {
+  LabelsCommand()
+      : super('labels',
+            'Report on the various labels in use by dart-lang repos.');
+
+  @override
+  Future<int> run() async {
+    var repos = getReposForOrg('dart-lang');
+
+    var results = <Repo, List<Label>>{};
+
+    for (var repo in await repos.toList()) {
+      var page = 1;
+      var lastItemCount = 0;
+      do {
+        var json = await callRestApi(Uri.parse(
+            'https://api.github.com/repos/${repo.org}/${repo.name}/labels?per_page=100&page=$page'));
+        var items = (jsonDecode(json!) as List).cast<Map>();
+        var labels = items.map((item) => Label(item.cast<String, dynamic>()));
+        results.putIfAbsent(repo, () => []).addAll(labels);
+
+        page++;
+        lastItemCount = items.length;
+      } while (lastItemCount > 0);
+
+      print('${repo.slug} has ${results[repo]!.length} labels '
+          '(${repo.openIssuesCount} issues, ${repo.stargazersCount} stars).');
+    }
+
+    print('');
+
+    // calculate label usage
+    var labels = <String, LabelInfo>{};
+
+    for (var entry in results.entries) {
+      var repo = entry.key;
+      if (repo.openIssuesCount < 30) continue;
+
+      for (var label in entry.value) {
+        var labelInfo =
+            labels.putIfAbsent(label.name, () => LabelInfo(label.name));
+
+        labelInfo.repos.add(repo.name);
+        labelInfo.weight += log(repo.openIssuesCount);
+      }
+    }
+
+    print('Label,Count,Weighted Repo,Repos');
+
+    var labelUsage = labels.values.toList()
+      ..sort((a, b) => b.repoCount - a.repoCount);
+
+    for (var info in labelUsage) {
+      print('${info.name},${info.repoCount},${info.weight.toStringAsFixed(1)},'
+          '"${info.repoNames}"');
+    }
+
+    return 0;
+  }
+}
+
+class Label {
+  Map<String, dynamic> json;
+
+  Label(this.json);
+
+  String get name => json['name'] as String;
+  String? get description => json['description'] as String?;
+  String get color => json['color'] as String;
+}
+
+class LabelInfo {
+  final String name;
+  final Set<String> repos = {};
+
+  double weight = 0.0;
+
+  LabelInfo(this.name);
+
+  int get repoCount => repos.length;
+
+  String get repoNames => (repos.toList()..sort()).join(',');
+}

--- a/pkgs/repo_query/lib/labels.dart
+++ b/pkgs/repo_query/lib/labels.dart
@@ -36,14 +36,19 @@ class LabelsCommand extends ReportCommand {
 
     for (var entry in results.entries) {
       var repo = entry.key;
-      if (repo.openIssuesCount < 30) continue;
+      var openIssues = repo.openIssuesCount;
+
+      // If a repo doesn't have very many issues, we don't want to give too much
+      // weight to how it's using labels (fewer issues means less need for a
+      // mature labeling strategy).
+      if (openIssues < 30) continue;
 
       for (var label in entry.value) {
         var labelInfo =
             labels.putIfAbsent(label.name, () => _LabelInfo(label.name));
 
         labelInfo.repos.add(repo.name);
-        labelInfo.weight += log(repo.openIssuesCount);
+        labelInfo.weight += log(openIssues);
       }
     }
 

--- a/pkgs/repo_query/lib/links.dart
+++ b/pkgs/repo_query/lib/links.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'src/common.dart';
+
+class LinksCommand extends ReportCommand {
+  LinksCommand() : super('links', 'List useful GitHub query urls.');
+
+  @override
+  Future<int> run() async {
+    var inThreeMonths = DateTime.now().subtract(Duration(days: 90));
+
+    print('''
+dart-lang P0 issues:
+  https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Adart-lang+label%3AP0
+
+dart-lang P1 issues:
+  https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Adart-lang+label%3AP1
+
+dart-lang PRs with no review:
+  https://github.com/pulls?q=is%3Aopen+is%3Apr+archived%3Afalse+org%3Adart-lang+review%3Anone
+
+dart-lang issues with more than 75 reactions:
+  https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Adart-lang+reactions%3A%3E75+sort%3Areactions-%2B1-desc+
+
+dart-lang P1 issues that haven't been updated in 3 months:
+  https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Adart-lang+label%3Ap1+updated%3A%3C${inThreeMonths.toIso8601String()}
+
+dart-lang issues with no label:
+  https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Adart-lang+no%3Alabel
+''');
+
+    return 0;
+  }
+}

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -146,5 +146,4 @@ final List<String> noteableRepos = [
   'dart-lang/webdev',
   'flutter/flutter',
   'flutter/packages',
-  'flutter/plugins',
 ];

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -35,8 +35,8 @@ String get githubToken {
   return token;
 }
 
-Future<QueryResult> query(QueryOptions options) {
-  return _client.query(options);
+Future<QueryResult<T>> query<T>(QueryOptions<T> options) {
+  return _client.query<T>(options);
 }
 
 String iso8601String(DateTime date) {

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
+import 'package:graphql/client.dart';
+import 'package:http/http.dart' as http;
+
+import '../branches.dart';
+import '../labels.dart';
+import '../links.dart';
+import '../weekly.dart';
+
+final GraphQLClient _client = _initGraphQLClient();
+
+GraphQLClient _initGraphQLClient() {
+  final token = githubToken;
+
+  final auth = AuthLink(getToken: () async => 'Bearer $token');
+  return GraphQLClient(
+    cache: GraphQLCache(),
+    link: auth.concat(HttpLink('https://api.github.com/graphql')),
+  );
+}
+
+String get githubToken {
+  var token = Platform.environment['GITHUB_TOKEN'];
+  if (token == null) {
+    throw StateError('This tool expects a github access token in the '
+        'GITHUB_TOKEN environment variable.');
+  }
+  return token;
+}
+
+Future<QueryResult> query(QueryOptions options) {
+  return _client.query(options);
+}
+
+String iso8601String(DateTime date) {
+  return date.toIso8601String().substring(0, 10);
+}
+
+abstract class ReportCommand extends Command<int> {
+  @override
+  final String name;
+
+  @override
+  final String description;
+
+  ReportCommand(this.name, this.description);
+
+  ReportCommandRunner get reportRunner => runner as ReportCommandRunner;
+
+  Future<String?> callRestApi(Uri uri) {
+    return reportRunner.callRestApi(uri);
+  }
+
+  Stream<Repo> getReposForOrg(String org) async* {
+    int? page = 1;
+
+    while (page != null) {
+      var json = await callRestApi(Uri.parse(
+          'https://api.github.com/orgs/$org/repos?sort=full_name&page=$page'));
+
+      var repos = (jsonDecode(json!) as List).cast<Map>();
+
+      for (var repo in repos) {
+        yield Repo(org, repo.cast<String, dynamic>());
+      }
+
+      if (repos.isEmpty) {
+        page = null;
+      } else {
+        page++;
+      }
+    }
+  }
+}
+
+class ReportCommandRunner extends CommandRunner<int> {
+  http.Client? _httpClient;
+
+  ReportCommandRunner()
+      : super('report',
+            'Run various reports on Dart and Flutter related repositories.') {
+    addCommand(BranchesCommand());
+    addCommand(LabelsCommand());
+    addCommand(LinksCommand());
+    addCommand(WeeklyCommand());
+  }
+
+  http.Client get httpClient => _httpClient ??= http.Client();
+
+  @override
+  Future<int?> runCommand(ArgResults topLevelResults) async {
+    try {
+      return super.runCommand(topLevelResults);
+    } finally {
+      close();
+    }
+  }
+
+  Future<String?> callRestApi(Uri uri) async {
+    return httpClient.get(uri, headers: {
+      'Authorization': 'token $githubToken',
+      'Accept': 'application/vnd.github+json',
+    }).then((response) {
+      return response.statusCode == 404 ? null : response.body;
+    });
+  }
+
+  void close() => _httpClient?.close();
+}
+
+class Repo {
+  final String org;
+  Map<String, dynamic> json;
+
+  Repo(this.org, this.json);
+
+  String get name => json['name'] as String;
+  String get defaultBranch => json['default_branch'] as String;
+  int get stargazersCount => json['stargazers_count'] as int;
+  int get openIssuesCount => json['open_issues_count'] as int;
+
+  String get slug => '$org/$name';
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Repo && other.name == name;
+  }
+}
+
+class RepoInfo {
+  final String repo;
+  final int issuesOpened;
+  final int issuesClosed;
+  final int commits;
+  final int p0Count;
+  final int p1Count;
+  final int stargazers;
+
+  RepoInfo(
+    this.repo, {
+    required this.issuesOpened,
+    required this.issuesClosed,
+    required this.commits,
+    required this.p0Count,
+    required this.p1Count,
+    required this.stargazers,
+  });
+}
+
+// This are monorepos, high-traffic repos, or otherwise noteable repos.
+final List<String> noteableRepos = [
+  'dart-lang/build',
+  'dart-lang/ecosystem',
+  'dart-lang/ffi',
+  'dart-lang/http',
+  'dart-lang/language',
+  'dart-lang/linter',
+  'dart-lang/pub',
+  'dart-lang/sdk',
+  'dart-lang/shelf',
+  'dart-lang/test',
+  'dart-lang/tools',
+  'dart-lang/webdev',
+  'flutter/flutter',
+  'flutter/packages',
+  'flutter/plugins',
+];

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -130,7 +130,7 @@ class RepoInfo {
   });
 }
 
-// This are monorepos, high-traffic repos, or otherwise noteable repos.
+// These are monorepos, high-traffic repos, or otherwise noteable repos.
 final List<String> noteableRepos = [
   'dart-lang/build',
   'dart-lang/ecosystem',

--- a/pkgs/repo_query/lib/weekly.dart
+++ b/pkgs/repo_query/lib/weekly.dart
@@ -1,0 +1,288 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:graphql/client.dart';
+
+import 'src/common.dart';
+
+class WeeklyCommand extends ReportCommand {
+  WeeklyCommand()
+      : super(
+            'weekly', 'Run a week-based report on repo status and activity.') {
+    argParser
+      ..addOption(
+        'date',
+        valueHelp: '2022-01-26',
+        help: 'Specify the date to pull data from '
+            '(defaults to the last full week).',
+      )
+      ..addFlag(
+        'dart-lang',
+        negatable: false,
+        help: 'Return stats for add dart-lang repos.',
+      )
+      ..addFlag(
+        'monthly',
+        negatable: false,
+        help: 'Return stats based on calendar months (instead of weeks).',
+      );
+  }
+
+  @override
+  Future<int> run() async {
+    final args = argResults!;
+    final byMonth = args['monthly'] as bool;
+    final allDartLang = args['dart-lang'] as bool;
+
+    late final DateTime firstReportingDay;
+    late final DateTime lastReportingDay;
+
+    if (byMonth) {
+      if (args.wasParsed('date')) {
+        final day = DateTime.parse(args['date'] as String);
+        firstReportingDay = DateTime(day.year, day.month, 1);
+      } else {
+        final now = DateTime.now();
+        firstReportingDay = DateTime(now.year, now.month - 1, 1);
+      }
+
+      lastReportingDay =
+          DateTime(firstReportingDay.year, firstReportingDay.month + 1, 1);
+    } else {
+      // by week
+      if (args.wasParsed('date')) {
+        final day = DateTime.parse(args['date'] as String);
+        firstReportingDay = day.subtract(Duration(days: day.weekday - 1));
+      } else {
+        final now = DateTime.now();
+        final currentDay = now.weekday;
+        final thisWeek = now.subtract(Duration(days: currentDay - 1));
+        firstReportingDay = thisWeek.subtract(Duration(days: 7));
+      }
+
+      lastReportingDay = firstReportingDay.add(Duration(days: 6));
+    }
+
+    var repos = noteableRepos.map(RepoSlug.new).toList();
+
+    if (allDartLang) {
+      repos = (await getReposForOrg('dart-lang').toList())
+          .map((r) => RepoSlug('dart-lang/${r.name}'))
+          .toList();
+    }
+
+    print(
+      'Reporting from ${iso8601String(firstReportingDay)} '
+      'to ${iso8601String(lastReportingDay)}...',
+    );
+
+    var infos = await Future.wait(repos.map((RepoSlug repo) async {
+      return RepoInfo(
+        repo.slug,
+        issuesOpened: await queryIssuesOpened(
+          repo: repo,
+          from: firstReportingDay,
+          to: lastReportingDay,
+        ),
+        issuesClosed: await queryIssuesClosed(
+          repo: repo,
+          from: firstReportingDay,
+          to: lastReportingDay,
+        ),
+        commits: await queryCommitsSince(
+          repo: repo,
+          since: firstReportingDay,
+          until: lastReportingDay,
+        ),
+        p0Count: await queryIssueCountForLabel(repo: repo, label: 'P0'),
+        p1Count: await queryIssueCountForLabel(repo: repo, label: 'P1'),
+        stargazers: await queryStargazers(repo: repo),
+      );
+    }));
+
+    print('');
+    print('Repo,Issues Opened,Issues Closed,Commits,P0s,P1s,Stars');
+
+    for (var info in infos) {
+      print(
+        '${info.repo},'
+        '${info.issuesOpened},'
+        '${info.issuesClosed},'
+        '${info.commits},'
+        '${info.p0Count},'
+        '${info.p1Count},'
+        '${info.stargazers}',
+      );
+    }
+
+    print('');
+
+    print(
+      'All: '
+      '${infos.fold(0, (count, info) => count + info.issuesOpened)} opened, '
+      '${infos.fold(0, (count, info) => count + info.issuesClosed)} closed, '
+      '${infos.fold(0, (count, info) => count + info.commits)} commits, '
+      '${infos.fold(0, (count, info) => count + info.p0Count)} P0s, '
+      '${infos.fold(0, (count, info) => count + info.p1Count)} P1s, '
+      '${infos.fold(0, (count, info) => count + info.stargazers)} stars',
+    );
+
+    return 0;
+  }
+
+  Future<int> queryIssuesOpened({
+    required RepoSlug repo,
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    final queryString = '''{
+  search(query: "repo:${repo.slug} is:issue created:${iso8601String(from)}..${iso8601String(to)}", type: ISSUE, last: 100) {
+  issueCount
+    edges {
+      node {
+        ... on Issue {
+          title
+          url
+          createdAt
+          number
+          state         
+        }
+      }
+    }
+  }
+}''';
+    final result = await query(QueryOptions(document: gql(queryString)));
+
+    if (result.hasException) {
+      throw result.exception!;
+    }
+
+    return (result.data!['search'] as Map)['issueCount']! as int;
+  }
+
+  Future<int> queryIssuesClosed({
+    required RepoSlug repo,
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    final queryString = '''{
+  search(query: "repo:${repo.slug} is:issue is:closed closed:${iso8601String(from)}..${iso8601String(to)}", type: ISSUE, last: 100) {
+  issueCount
+    edges {
+      node {
+        ... on Issue {
+          title
+          url
+          createdAt
+          number
+          state         
+        }
+      }
+    }
+  }
+}''';
+    final result = await query(QueryOptions(document: gql(queryString)));
+
+    if (result.hasException) {
+      throw result.exception!;
+    }
+
+    return (result.data!['search'] as Map)['issueCount']! as int;
+  }
+
+  Future<int> queryCommitsSince({
+    required RepoSlug repo,
+    required DateTime since,
+    required DateTime until,
+  }) async {
+    final queryString = '''{
+  repository(owner: "${repo.org}", name: "${repo.name}") {
+    defaultBranchRef {
+      target {
+        ... on Commit {
+          history(since: "${since.toIso8601String()}", until: "${until.toIso8601String()}") {
+            totalCount
+          }
+        }
+      }
+    }
+  }
+}''';
+
+    final result = await query(QueryOptions(document: gql(queryString)));
+    if (result.hasException) {
+      throw result.exception!;
+    }
+    var target = ((result.data!['repository'] as Map)['defaultBranchRef']
+        as Map)['target'] as Map?;
+    if (target == null) {
+      print('no repo history available for $repo');
+      return 0;
+    }
+    return (target['history'] as Map)['totalCount'] as int;
+  }
+
+  Future<int> queryIssueCountForLabel({
+    required RepoSlug repo,
+    required String label,
+  }) async {
+    final queryString = '''query {
+  repository(owner:"${repo.org}", name:"${repo.name}") {
+    issues(states:OPEN labels:"$label") {
+      totalCount
+    }
+  }
+}
+''';
+
+    final result = await query(QueryOptions(document: gql(queryString)));
+    if (result.hasException) {
+      throw result.exception!;
+    }
+    var issues = (result.data!['repository'] as Map)['issues'] as Map?;
+    if (issues == null) {
+      print('error querying issues for $repo');
+      return 0;
+    }
+    return issues['totalCount'] as int;
+  }
+
+  Future<int> queryStargazers({
+    required RepoSlug repo,
+  }) async {
+    final queryString = '''query {
+  repository(owner:"${repo.org}", name:"${repo.name}") {
+    stargazerCount
+  }
+}
+''';
+
+    final result = await query(QueryOptions(document: gql(queryString)));
+    if (result.hasException) {
+      throw result.exception!;
+    }
+    var count = (result.data!['repository'] as Map)['stargazerCount'] as int;
+    return count;
+  }
+}
+
+class RepoSlug {
+  final String slug;
+
+  RepoSlug(this.slug);
+
+  String get org => slug.split('/')[0];
+  String get name => slug.split('/')[1];
+
+  @override
+  int get hashCode => slug.hashCode;
+
+  @override
+  String toString() => slug;
+
+  @override
+  bool operator ==(Object other) {
+    return other is RepoSlug && slug == other.slug;
+  }
+}

--- a/pkgs/repo_query/mono_pkg.yaml
+++ b/pkgs/repo_query/mono_pkg.yaml
@@ -1,0 +1,13 @@
+# See https://github.com/google/mono_repo.dart
+sdk:
+- pubspec
+- dev
+
+stages:
+- analyze_and_format:
+  - analyze: --fatal-infos .
+  - format:
+    sdk:
+    - dev
+- unit_test:
+  - test

--- a/pkgs/repo_query/mono_pkg.yaml
+++ b/pkgs/repo_query/mono_pkg.yaml
@@ -9,5 +9,3 @@ stages:
   - format:
     sdk:
     - dev
-- unit_test:
-  - test

--- a/pkgs/repo_query/pubspec.yaml
+++ b/pkgs/repo_query/pubspec.yaml
@@ -1,0 +1,16 @@
+name: repo_query
+description: Miscellaneous issue, repo, and PR query tools.
+
+publish_to: none
+
+environment:
+  sdk: ^2.19.0
+
+dependencies:
+  args: any
+  graphql: any
+  http: any
+  path: any
+
+dev_dependencies:
+  dart_flutter_team_lints: any

--- a/pkgs/repo_query/pubspec.yaml
+++ b/pkgs/repo_query/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   args: any
+  github: any
   graphql: any
-  http: any
   path: any
 
 dev_dependencies:

--- a/pkgs/repo_query/pubspec_overrides.yaml
+++ b/pkgs/repo_query/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  dart_flutter_team_lints:
+    path: ../dart_flutter_team_lints


### PR DESCRIPTION
- contribute a repo query tool and scripts

```
Run various reports on Dart and Flutter related repositories.

Usage: report <command> [arguments]

Global options:
-h, --help    Print this usage information.

Available commands:
  branches   Show the default branch names of Dart and Flutter repos.
  labels     Report on the various labels in use by dart-lang repos.
  links      List useful GitHub query urls.
  weekly     Run a week-based report on repo status and activity.

Run "report help <command>" for more information about a command.
```