### PR TITLE
add a 'labels-update' command

### DIFF
--- a/pkgs/repo_query/README.md
+++ b/pkgs/repo_query/README.md
@@ -9,10 +9,11 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
-  branches   Show the default branch names of Dart and Flutter repos.
-  labels     Report on the various labels in use by dart-lang repos.
-  links      List useful GitHub query urls.
-  weekly     Run a week-based report on repo status and activity.
+  branches        Show the default branch names of Dart and Flutter repos.
+  labels          Report on the various labels in use by dart-lang repos.
+  labels-update   Audit and update the labels used by dart-lang repos.
+  links           List useful GitHub query urls.
+  weekly          Run a week-based report on repo status and activity.
 
 Run "report help <command>" for more information about a command.
 ```

--- a/pkgs/repo_query/lib/labels.dart
+++ b/pkgs/repo_query/lib/labels.dart
@@ -25,7 +25,7 @@ class LabelsCommand extends ReportCommand {
 
       results[repo] = labels;
 
-      print('${repo.slug} has ${results[repo]!.length} labels '
+      print('${repo.slug()} has ${results[repo]!.length} labels '
           '(${repo.openIssuesCount} issues, ${repo.stargazersCount} stars).');
     }
 

--- a/pkgs/repo_query/lib/labels_update.dart
+++ b/pkgs/repo_query/lib/labels_update.dart
@@ -59,10 +59,6 @@ const String templateRepoSlug = 'dart-lang/.github';
 /// If a package:<name> label exists, ensure it has this color.
 final String packageLabelColor = '4774bc';
 
-// todo: help
-// todo: --dry-run
-// todo: --apply-changes
-
 class LabelsUpdateCommand extends ReportCommand {
   LabelsUpdateCommand()
       : super('labels-update',
@@ -83,13 +79,15 @@ class LabelsUpdateCommand extends ReportCommand {
   @override
   Future<int> run() async {
     var applyChanges = argResults!['apply-changes'] as bool;
-
     var rest = argResults!.rest;
+
     if (rest.isEmpty) {
-      stderr.writeln('For the --audit flag, provide a repo slug '
-          '(e.g. dart-lang/foo_repo).');
+      stderr.writeln('Please provide a repo slug (e.g. dart-lang/foo_repo).');
+      stderr.writeln();
+      stderr.writeln(usage);
       return 1;
     }
+
     return await performAudit(rest, alsoFix: applyChanges);
   }
 

--- a/pkgs/repo_query/lib/labels_update.dart
+++ b/pkgs/repo_query/lib/labels_update.dart
@@ -64,6 +64,12 @@ class LabelsUpdateCommand extends ReportCommand {
       : super('labels-update',
             'Audit and update the labels used by dart-lang repos.') {
     argParser.addFlag(
+      'dry-run',
+      negatable: false,
+      help: "Audit the labels used but don't make any changes to the given "
+          'repos.',
+    );
+    argParser.addFlag(
       'apply-changes',
       negatable: false,
       help: 'Rename, edit, and add labels to bring them in line with those '
@@ -78,8 +84,14 @@ class LabelsUpdateCommand extends ReportCommand {
 
   @override
   Future<int> run() async {
+    var dryRun = argResults!['dry-run'] as bool;
     var applyChanges = argResults!['apply-changes'] as bool;
     var rest = argResults!.rest;
+
+    if (!dryRun && !applyChanges) {
+      stdout.writeln(usage);
+      return 0;
+    }
 
     if (rest.isEmpty) {
       stderr.writeln('Please provide a repo slug (e.g. dart-lang/foo_repo).');

--- a/pkgs/repo_query/lib/labels_update.dart
+++ b/pkgs/repo_query/lib/labels_update.dart
@@ -1,0 +1,302 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:github/github.dart';
+
+import 'src/common.dart';
+
+/// A map from the desired canonical label name to the synonyms for that label
+/// currently in use by various dart-lang repos.
+final Map<String, List<String>> synonyms = {
+  'closed-as-intended': [
+    'resolution: intended',
+    'resolution: works as intended',
+  ],
+  'closed-cannot-reproduce': ['cannot reproduce', 'cannot-reproduce'],
+  'closed-duplicate': ['duplicate', 'resolution: duplicate'],
+  'closed-invalid': ['invalid', 'resolution: invalid'],
+  'closed-not-planned': [
+    'not planned',
+    'resolution: not planned',
+    'resolution: wontfix',
+    'wontfix',
+  ],
+  'contributions-welcome': ['help wanted', 'state: help wanted'],
+  'P0': ['p0 critical', 'p0', 'p0-critical'],
+  'P1': ['p1 high', 'p1', 'p1-high'],
+  'P2': ['p2 medium', 'p2', 'p2-medium'],
+  'P3': ['p3 low', 'p3', 'p3-low'],
+  'status-blocked': ['blocked', 'state: blocked'],
+  'status-needs-info': [
+    'needs info',
+    'needs-info',
+    'state: needs info',
+    'waiting for customer response',
+  ],
+  'type-bug': ['bug', 'type: bug'],
+  'type-code-health': ['code health'],
+  'type-documentation': ['documentation', 'docs'],
+  'type-enhancement': ['enhancement', 'type: enhancement'],
+  'type-infra': ['github_actions', 'infrastructure', 'infra'],
+  'type-performance': ['performance', 'type: perf'],
+  'type-question': ['question', 'type: question'],
+  'type-ux': ['ux'],
+};
+
+/// These single-word label names are grandfathered in.
+final Set<String> allowList = {
+  'dependencies',
+  'Epic',
+  'meta',
+};
+
+/// The cannonical set of dart-lang labels.
+const String templateRepoSlug = 'dart-lang/.github';
+
+/// If a package:<name> label exists, ensure it has this color.
+final String packageLabelColor = '4774bc';
+
+// todo: help
+// todo: --dry-run
+// todo: --apply-changes
+
+class LabelsUpdateCommand extends ReportCommand {
+  LabelsUpdateCommand()
+      : super('labels-update',
+            'Audit and update the labels used by dart-lang repos.') {
+    argParser.addFlag(
+      'apply-changes',
+      negatable: false,
+      help: 'Rename, edit, and add labels to bring them in line with those '
+          "at $templateRepoSlug.\nWARNING: this will make changes to a repo's "
+          'labels; please preview the changes first by running without '
+          "'--apply-changes'.",
+    );
+  }
+
+  @override
+  String get invocation => '${super.invocation} <repo-org/repo-name>';
+
+  @override
+  Future<int> run() async {
+    var applyChanges = argResults!['apply-changes'] as bool;
+
+    var rest = argResults!.rest;
+    if (rest.isEmpty) {
+      stderr.writeln('For the --audit flag, provide a repo slug '
+          '(e.g. dart-lang/foo_repo).');
+      return 1;
+    }
+    return await performAudit(rest, alsoFix: applyChanges);
+  }
+
+  Future<int> performAudit(
+    List<String> repoSlugs, {
+    required bool alsoFix,
+  }) async {
+    final templateRepo = RepositorySlug.full(templateRepoSlug);
+
+    var templateLabels =
+        await reportRunner.github.issues.listLabels(templateRepo).toList()
+          ..sort(labelCompare);
+
+    print('## template repo: $templateRepo');
+    for (var label in templateLabels) {
+      print('  ${label.name} 0x${label.color} "${label.description}"');
+    }
+
+    final templateSet = templateLabels.map((l) => l.name).toSet();
+
+    for (var slug in repoSlugs) {
+      print('');
+      print('## $slug');
+
+      final labelsEncountered = <String>{};
+
+      var labels = await reportRunner.github.issues
+          .listLabels(RepositorySlug.full(slug))
+          .toList()
+        ..sort(labelCompare);
+
+      var advisories = <String, String>{};
+      var edits = <String, LabelEdit>{};
+
+      for (var label in labels) {
+        IssueLabel? templateLabel;
+
+        if (templateSet.contains(label.name)) {
+          labelsEncountered.add(label.name);
+          templateLabel =
+              templateLabels.firstWhere((l) => l.name == label.name);
+        } else if (checkSynonym(label.name) != null) {
+          var renameTo = checkSynonym(label.name);
+          labelsEncountered.add(renameTo!);
+          edits
+              .putIfAbsent(label.name, LabelEdit.new)
+              .join(LabelEdit(newName: renameTo));
+          templateLabel = templateLabels.firstWhere((l) => l.name == renameTo);
+        } else if (wellFormed(label.name) != null) {
+          advisories[label.name] = wellFormed(label.name)!;
+        }
+
+        if (templateLabel != null) {
+          if (templateLabel.color != label.color) {
+            var edit = edits.putIfAbsent(label.name, LabelEdit.new);
+            edit.join(LabelEdit(color: templateLabel.color));
+          }
+          if (templateLabel.description != label.description) {
+            var edit = edits.putIfAbsent(label.name, LabelEdit.new);
+            edit.join(LabelEdit(description: templateLabel.description));
+          }
+        }
+
+        // package: colors
+        if (label.name.startsWith('package:') &&
+            label.color != packageLabelColor) {
+          edits
+              .putIfAbsent(label.name, LabelEdit.new)
+              .join(LabelEdit(color: packageLabelColor));
+        }
+      }
+
+      var adds = templateSet.difference(labelsEncountered).map((name) {
+        var templateLabel = templateLabels.firstWhere((l) => l.name == name);
+        return LabelEdit(
+          newName: name,
+          color: templateLabel.color,
+          description: templateLabel.description,
+        );
+      });
+
+      // renames
+      for (var entry in edits.entries.where((e) => e.value.newName != null)) {
+        print('  (rename) ${entry.key}: ${entry.value}');
+      }
+
+      // updates
+      for (var entry in edits.entries.where((e) => e.value.newName == null)) {
+        print('  (update) ${entry.key}: ${entry.value}');
+      }
+
+      // adds
+      for (var edit in adds) {
+        print('  (add) ${edit.newName}: #${edit.color} "${edit.description}"');
+      }
+
+      // advisories
+      for (var entry in advisories.entries) {
+        print('  (consistency) ${entry.key}: ${entry.value}');
+      }
+
+      if (alsoFix) {
+        print('');
+        print('Updating labels for $slug');
+
+        var repoSlug = RepositorySlug.full(slug);
+        var repo =
+            await reportRunner.github.repositories.getRepository(repoSlug);
+        print('  $slug has ${repo.openIssuesCount} issues and '
+            '${labels.length} labels.');
+
+        if (slug == templateRepoSlug || slug == 'dart-lang/sdk') {
+          print("  skipping: won't update labels for $slug.");
+        } else if (repo.openIssuesCount >= 100) {
+          print("  skipping: won't update labels when issue count >=100.");
+        } else {
+          // Perform updates.
+          for (var entry in edits.entries) {
+            var oldName = entry.key;
+            var edit = entry.value;
+
+            print('  updating $oldName: $edit');
+            await reportRunner.github.issues.updateLabel(
+              repoSlug,
+              oldName,
+              newName: edit.newName,
+              color: edit.color,
+              description: edit.description,
+            );
+          }
+
+          for (var edit in adds) {
+            print('  adding ${edit.newName}');
+            await reportRunner.github.issues.createLabel(
+              repoSlug,
+              edit.newName!,
+              color: edit.color,
+              description: edit.description,
+            );
+          }
+
+          print('');
+          print('  ${repo.htmlUrl}/labels');
+        }
+      }
+    }
+
+    return 0;
+  }
+}
+
+String? checkSynonym(String label) {
+  for (var entry in synonyms.entries) {
+    if (entry.value.contains(label.toLowerCase())) {
+      return entry.key;
+    }
+  }
+
+  return null;
+}
+
+String? wellFormed(String label) {
+  if (allowList.contains(label)) return null;
+
+  if (label.startsWith('package:')) {
+    const avoidPrefix = 'package: ';
+    if (label.startsWith(avoidPrefix)) {
+      return 'rename to package:${label.substring(avoidPrefix.length)}';
+    } else {
+      return null;
+    }
+  } else if (label.startsWith('pkg:')) {
+    return 'rename to package:${label.substring('pkg:'.length)}';
+  } else if (label.contains(' ')) {
+    return 'avoid spaces; use lowercase-dashes to join words';
+  } else if (label != label.toLowerCase()) {
+    return 'avoid upper case; use lowercase names';
+  } else if (!label.contains('-')) {
+    return 'avoid single word labels (prefer using a category prefix)';
+  }
+
+  return null;
+}
+
+int labelCompare(IssueLabel a, IssueLabel b) {
+  return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+}
+
+class LabelEdit {
+  String? newName;
+  String? color;
+  String? description;
+
+  LabelEdit({this.newName, this.color, this.description});
+
+  void join(LabelEdit other) {
+    newName ??= other.newName;
+    color ??= other.color;
+    description ??= other.description;
+  }
+
+  @override
+  String toString() {
+    return [
+      if (newName != null) 'rename => $newName',
+      if (color != null) 'color => #$color',
+      if (description != null) 'description => "${overflow(description!)}"',
+    ].join(', ');
+  }
+}

--- a/pkgs/repo_query/lib/labels_update.dart
+++ b/pkgs/repo_query/lib/labels_update.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:github/github.dart';
 
 import 'src/common.dart';
@@ -57,7 +58,7 @@ final Set<String> allowList = {
 const String templateRepoSlug = 'dart-lang/.github';
 
 /// If a package:<name> label exists, ensure it has this color.
-final String packageLabelColor = '4774bc';
+final String packageColor = '4774bc';
 
 class LabelsUpdateCommand extends ReportCommand {
   LabelsUpdateCommand()
@@ -164,11 +165,10 @@ class LabelsUpdateCommand extends ReportCommand {
         }
 
         // package: colors
-        if (label.name.startsWith('package:') &&
-            label.color != packageLabelColor) {
+        if (label.name.startsWith('package:') && label.color != packageColor) {
           edits
               .putIfAbsent(label.name, LabelEdit.new)
-              .join(LabelEdit(color: packageLabelColor));
+              .join(LabelEdit(color: packageColor));
         }
       }
 
@@ -252,22 +252,18 @@ class LabelsUpdateCommand extends ReportCommand {
 }
 
 String? checkSynonym(String label) {
-  for (var entry in synonyms.entries) {
-    if (entry.value.contains(label.toLowerCase())) {
-      return entry.key;
-    }
-  }
-
-  return null;
+  return synonyms.entries
+      .firstWhereOrNull((entry) => entry.value.contains(label.toLowerCase()))
+      ?.key;
 }
 
 String? wellFormed(String label) {
   if (allowList.contains(label)) return null;
 
   if (label.startsWith('package:')) {
-    const avoidPrefix = 'package: ';
-    if (label.startsWith(avoidPrefix)) {
-      return 'rename to package:${label.substring(avoidPrefix.length)}';
+    final packageName = label.substring('package:'.length);
+    if (packageName != packageName.trim()) {
+      return 'rename to package:${packageName.trim()}';
     } else {
       return null;
     }

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -11,6 +11,7 @@ import 'package:graphql/client.dart';
 
 import '../branches.dart';
 import '../labels.dart';
+import '../labels_update.dart';
 import '../links.dart';
 import '../weekly.dart';
 
@@ -43,6 +44,10 @@ String iso8601String(DateTime date) {
   return date.toIso8601String().substring(0, 10);
 }
 
+String overflow(String str, [int overflows = 40]) {
+  return str.length <= overflows ? str : '${str.substring(0, overflows)}...';
+}
+
 abstract class ReportCommand extends Command<int> {
   @override
   final String name;
@@ -69,6 +74,7 @@ class ReportCommandRunner extends CommandRunner<int> {
             'Run various reports on Dart and Flutter related repositories.') {
     addCommand(BranchesCommand());
     addCommand(LabelsCommand());
+    addCommand(LabelsUpdateCommand());
     addCommand(LinksCommand());
     addCommand(WeeklyCommand());
   }
@@ -79,7 +85,7 @@ class ReportCommandRunner extends CommandRunner<int> {
   @override
   Future<int?> runCommand(ArgResults topLevelResults) async {
     try {
-      return super.runCommand(topLevelResults);
+      return await super.runCommand(topLevelResults);
     } finally {
       close();
     }

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -45,7 +45,7 @@ String iso8601String(DateTime date) {
 }
 
 String overflow(String str, [int overflows = 40]) {
-  return str.length <= overflows ? str : '${str.substring(0, overflows)}...';
+  return str.length <= overflows ? str : '${str.substring(0, overflows - 3)}...';
 }
 
 abstract class ReportCommand extends Command<int> {

--- a/pkgs/repo_query/lib/src/common.dart
+++ b/pkgs/repo_query/lib/src/common.dart
@@ -45,7 +45,9 @@ String iso8601String(DateTime date) {
 }
 
 String overflow(String str, [int overflows = 40]) {
-  return str.length <= overflows ? str : '${str.substring(0, overflows - 3)}...';
+  return str.length <= overflows
+      ? str
+      : '${str.substring(0, overflows - 3)}...';
 }
 
 abstract class ReportCommand extends Command<int> {

--- a/pkgs/repo_query/pubspec.yaml
+++ b/pkgs/repo_query/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   args: ^2.4.0
+  collection: ^1.17.0
   github: ^9.0.0
   graphql: ^5.0.0
   path: ^1.8.0

--- a/pkgs/repo_query/pubspec.yaml
+++ b/pkgs/repo_query/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: ^2.19.0
 
 dependencies:
-  args: any
-  github: any
-  graphql: any
-  path: any
+  args: ^2.4.0
+  github: ^9.0.0
+  graphql: ^5.0.0
+  path: ^1.8.0
 
 dev_dependencies:
-  dart_flutter_team_lints: any
+  dart_flutter_team_lints: ^1.0.0

--- a/pkgs/repo_query/pubspec_overrides.yaml
+++ b/pkgs/repo_query/pubspec_overrides.yaml
@@ -1,3 +1,7 @@
 dependency_overrides:
   dart_flutter_team_lints:
     path: ../dart_flutter_team_lints
+
+  # TODO: Remove once https://github.com/SpinlockLabs/github.dart/pull/355 lands.
+  github:
+    path: /Users/devoncarew/projects/SpinlockLabs/github.dart

--- a/pkgs/repo_query/pubspec_overrides.yaml
+++ b/pkgs/repo_query/pubspec_overrides.yaml
@@ -4,4 +4,6 @@ dependency_overrides:
 
   # TODO: Remove once https://github.com/SpinlockLabs/github.dart/pull/355 lands.
   github:
-    path: /Users/devoncarew/projects/SpinlockLabs/github.dart
+    git:
+      url: https://github.com/devoncarew/github.dart.git
+      ref: labels_apis


### PR DESCRIPTION
Add a 'labels-update' command:
- read the (proposed canonical) labels from dart-lang/.github and print the diffs to a given repo (`--dry-run`)
- or, do the same, but apply the proposed changes (renames, descriptions updates, and label additions) - `--apply-changes`

```
Audit and update the labels used by dart-lang repos.

Usage: report labels-update [arguments] <repo-org/repo-name>
-h, --help             Print this usage information.
    --dry-run          Audit the labels used but don't make any changes to the given repos.
    --apply-changes    Rename, edit, and add labels to bring them in line with those at dart-lang/.github.
                       WARNING: this will make changes to a repo's labels; please preview the changes first by running without '--apply-changes'.

Run "report help" to see global options.
```
