### PR TITLE
support an 'publish-ignore-warnings' label

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,7 @@ name: Publish
 # on:
 #   pull_request:
 #     branches: [ main ]
+#     types: [opened, synchronize, reopened, labeled, unlabeled]
 #   push:
 #     tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 # jobs:
@@ -61,6 +62,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.number }}
+          PR_LABELS: "${{ join(github.event.pull_request.labels.*.name) }}"
         run: dart pub global run firehose --validate
 
       - name: Publish packages

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -8,6 +8,7 @@ name: Publish
 on:
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
@@ -35,6 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.number }}
+          PR_LABELS: "${{ join(github.event.pull_request.labels.*.name) }}"
         run: dart pkgs/firehose/bin/firehose.dart --validate
 
       - name: Publish tagged package

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 0.3.14-dev
+## 0.3.14
 
 - Require Dart `2.19.0`.
 - Adjust docs for the recommended tag format to use to trigger publishing
   (support semver release versions, not pre-release versions).
+- Support using a `publish-ignore-warnings` label to ignore `dart pub publish`
+  dry-run validation failures.
+- Update the recommended publish.yaml file to listen for label changes on PRs
+  (`types: ...`).
 
 ## 0.3.13
 

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -69,6 +69,7 @@ name: Publish
 on:
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -160,11 +160,11 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
 
         if (code != 0 && !ignoreWarnings) {
           exitCode = code;
-          results.addResult(Result.fail(
-            package,
-            'pub publish dry-run failed '
-            '(add `$_ignoreWarningsLabel` label to ignore)',
-          ));
+          var message =
+              'pub publish dry-run failed; add the `$_ignoreWarningsLabel` '
+              'label to ignore';
+          github.notice(message: message);
+          results.addResult(Result.fail(package, message));
         } else {
           var result = Result.success(package,
               '**ready to publish** (merge and tag to publish)', repoTag);

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -27,6 +27,10 @@ class Github {
   /// The PR (or issue) number.
   String? get issueNumber => _env['ISSUE_NUMBER'];
 
+  /// Any labels applied to this PR.
+  List<String> get prLabels =>
+      _env.containsKey('PR_LABELS') ? _env['PR_LABELS']!.split(',') : [];
+
   /// The commit SHA that triggered the workflow.
   String? get sha => _env['GITHUB_SHA'];
 

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -195,6 +195,11 @@ class Github {
   void close() {
     _httpClient?.close();
   }
+
+  /// Write a notice message to the github log.
+  void notice({required String message}) {
+    print('::notice ::$message');
+  }
 }
 
 class RpcException implements Exception {

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,7 +1,14 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.14-dev
+version: 0.3.14
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
+
+# todo: temporary change to trigger a publish warning
+authors:
+  - devoncarew@google.con
+
+# todo: test no labels
+# todo: test multiple labels
 
 environment:
   sdk: '>=2.19.0 <3.0.0'

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -3,13 +3,6 @@ description: A tool to automate publishing of Pub packages from GitHub actions.
 version: 0.3.14
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
-# todo: temporary change to trigger a publish warning
-authors:
-  - devoncarew@google.con
-
-# todo: test no labels
-# todo: test multiple labels
-
 environment:
   sdk: '>=2.19.0 <3.0.0'
 


### PR DESCRIPTION
support an 'publish-ignore-warnings' label:
- listen for label changes on PRs
- when a PR has a `publish-ignore-warnings`, run the pub dry run checks, but don't fail the build if they report errors
- address https://github.com/dart-lang/ecosystem/issues/64, #75 

This will allow repo committers to see publish warnings, but ignore them for a specific run.
