### PR TITLE
fix a pkg/blast_repo test

### DIFF
--- a/pkgs/blast_repo/pubspec.yaml
+++ b/pkgs/blast_repo/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   pub_semver: ^2.1.2
   stack_trace: ^1.11.0
   yaml: ^3.1.0
-  yaml_edit: ^2.0.3
+  yaml_edit: ^2.1.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^1.0.0

--- a/pkgs/blast_repo/test/dependabot_test.dart
+++ b/pkgs/blast_repo/test/dependabot_test.dart
@@ -49,7 +49,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
- fix a pkg/blast_repo test

This updates our test expectations for the latest version of `yaml_edit`.