### PR TITLE
make publish tags link to the release page with populated fields

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.15-wip
+
+- Make publish tags link to the new release page for that tag, with
+  pre-populated fields.
+
 ## 0.3.14
 
 - Require Dart `2.19.0`.
@@ -20,7 +25,7 @@
 
 ## 0.3.11
 
-- Add additional console logging when we encounter GitHub API errors. 
+- Add additional console logging when we encounter GitHub API errors.
 
 ## 0.3.10
 

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.15-wip
+## 0.3.15
 
 - Make publish tags link to the new release page for that tag, with
   pre-populated fields.

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -47,7 +47,7 @@ class Firehose {
     var results = await _validate(github);
 
     var markdownTable = '''
-| Package | Version | Status | Post-merge release link |
+| Package | Version | Status | Publish tag (post-merge) |
 | :--- | ---: | :--- | ---: |
 ${results.describeAsMarkdown}
 

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -47,7 +47,7 @@ class Firehose {
     var results = await _validate(github);
 
     var markdownTable = '''
-| Package | Version | Status | Publish tag |
+| Package | Version | Status | Publish release (post-merge) |
 | :--- | ---: | :--- | ---: |
 ${results.describeAsMarkdown}
 

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -166,8 +166,11 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
           github.notice(message: message);
           results.addResult(Result.fail(package, message));
         } else {
-          var result = Result.success(package,
-              '**ready to publish** (merge and tag to publish)', repoTag);
+          var result = Result.success(
+              package,
+              '**ready to publish** (merge and tag to publish)',
+              repoTag,
+              repo.calculateReleaseUri(package, github));
           print(result);
           results.addResult(result);
         }
@@ -299,6 +302,10 @@ class VerificationResults {
     return results.map((r) {
       var sev = r.severity == Severity.error ? '(error) ' : '';
       var tag = r.gitTag == null ? '' : '`${r.gitTag}`';
+      var publishReleaseUri = r.publishReleaseUri;
+      if (publishReleaseUri != null) {
+        tag = '[$tag]($publishReleaseUri)';
+      }
 
       return '| package:${r.package.name} | ${r.package.version} | '
           '$sev${r.message} | $tag |';
@@ -311,8 +318,10 @@ class Result {
   final Package package;
   final String message;
   final String? gitTag;
+  final Uri? publishReleaseUri;
 
-  Result(this.severity, this.package, this.message, [this.gitTag]);
+  Result(this.severity, this.package, this.message,
+      [this.gitTag, this.publishReleaseUri]);
 
   factory Result.fail(Package package, String message) =>
       Result(Severity.error, package, message);
@@ -320,8 +329,9 @@ class Result {
   factory Result.info(Package package, String message) =>
       Result(Severity.info, package, message);
 
-  factory Result.success(Package package, String message, [String? gitTag]) =>
-      Result(Severity.success, package, message, gitTag);
+  factory Result.success(Package package, String message,
+          [String? gitTag, Uri? publishReleaseUri]) =>
+      Result(Severity.success, package, message, gitTag, publishReleaseUri);
 
   @override
   String toString() {

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -47,7 +47,7 @@ class Firehose {
     var results = await _validate(github);
 
     var markdownTable = '''
-| Package | Version | Status | Publish release (post-merge) |
+| Package | Version | Status | Post-merge release link |
 | :--- | ---: | :--- | ---: |
 ${results.describeAsMarkdown}
 
@@ -166,10 +166,7 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
           github.notice(message: message);
           results.addResult(Result.fail(package, message));
         } else {
-          var result = Result.success(
-              package,
-              '**ready to publish** (merge and tag to publish)',
-              repoTag,
+          var result = Result.success(package, '**ready to publish**', repoTag,
               repo.calculateReleaseUri(package, github));
           print(result);
           results.addResult(result);

--- a/pkgs/firehose/lib/src/repo.dart
+++ b/pkgs/firehose/lib/src/repo.dart
@@ -8,6 +8,7 @@ import 'package:firehose/src/changelog.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart' as yaml;
 
+import 'github.dart';
 import 'pubspec.dart';
 
 class Repository {
@@ -64,6 +65,14 @@ class Repository {
     } else {
       return '${package.name}-v${package.pubspec.version}';
     }
+  }
+
+  Uri calculateReleaseUri(Package package, Github github) {
+    final tag = calculateRepoTag(package);
+    final title = '${package.name} version ${package.pubspec.version}';
+    final body = package.changelog.describeLatestChanges;
+    return Uri.https('github.com', '/${github.repoSlug}/releases/new',
+        {'tag': tag, 'title': title, 'body': body});
   }
 }
 

--- a/pkgs/firehose/lib/src/repo.dart
+++ b/pkgs/firehose/lib/src/repo.dart
@@ -69,7 +69,7 @@ class Repository {
 
   Uri calculateReleaseUri(Package package, Github github) {
     final tag = calculateRepoTag(package);
-    final title = '${package.name} version ${package.pubspec.version}';
+    final title = 'package:${package.name} v${package.pubspec.version}';
     final body = package.changelog.describeLatestChanges;
     return Uri.https('github.com', '/${github.repoSlug}/releases/new',
         {'tag': tag, 'title': title, 'body': body});

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.14
+version: 0.3.15-wip
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.15-wip
+version: 0.3.15
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/test/repo_test.dart
+++ b/pkgs/firehose/test/repo_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firehose/src/github.dart';
 import 'package:firehose/src/repo.dart';
 import 'package:test/test.dart';
 
@@ -21,6 +22,18 @@ void main() {
     test('locatePackages', () {
       var result = packages.locatePackages();
       expect(result, isNotEmpty);
+    });
+
+    test('github release link', () {
+      final github = Github();
+      final package = packages.locatePackages().single;
+      final releaseUri = packages.calculateReleaseUri(package, github);
+      expect(releaseUri.path, '/${github.repoSlug}/releases/new');
+      final queryParams = releaseUri.queryParameters;
+      expect(queryParams['tag'], packages.calculateRepoTag(package));
+      expect(queryParams['title'],
+          allOf(contains(package.name), contains(package.version)));
+      expect(queryParams['body'], package.changelog.describeLatestChanges);
     });
   });
 }


### PR DESCRIPTION
Updates the markdown table so that "publish tag" tags are links to a release page with all the information pre-populated.