### PR TITLE
fix: More robust version check

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.16
+
+- More robust version checking, now more diverse changelog formats are accepted.
+
 ## 0.3.15
 
 - Make publish tags link to the new release page for that tag, with

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -130,7 +130,7 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
       print('changelog:');
       print(package.changelog.describeLatestChanges.trimRight());
 
-      if (pubspecVersion != changelogVersion) {
+      if (!changelogVersion.toString().contains(pubspecVersion)) {
         var result = Result.fail(
           package,
           'pubspec version ($pubspecVersion) and changelog ($changelogVersion) '

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -130,7 +130,7 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
       print('changelog:');
       print(package.changelog.describeLatestChanges.trimRight());
 
-      if (!changelogVersion.toString().contains(pubspecVersion)) {
+      if (pubspecVersion != changelogVersion) {
         var result = Result.fail(
           package,
           'pubspec version ($pubspecVersion) and changelog ($changelogVersion) '

--- a/pkgs/firehose/lib/src/changelog.dart
+++ b/pkgs/firehose/lib/src/changelog.dart
@@ -36,6 +36,7 @@ class Changelog {
 
   String? get latestHeading {
     var sections = _parseSections();
+    // Remove all leading "#"
     return sections.firstOrNull?.title.replaceAll(RegExp(r'^#*'), '').trim();
   }
 

--- a/pkgs/firehose/lib/src/changelog.dart
+++ b/pkgs/firehose/lib/src/changelog.dart
@@ -14,8 +14,29 @@ class Changelog {
   bool get exists => file.existsSync();
 
   String? get latestVersion {
+    var input = latestHeading;
+
+    if (input == null) {
+      return null;
+    }
+
+    final versionRegex = RegExp(r'[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?');
+
+    var match = versionRegex.firstMatch(input);
+
+    if (match != null) {
+      var version = match.group(0);
+      print('Version: $version');
+      return version;
+    } else {
+      print('No version number found.');
+    }
+    return null;
+  }
+
+  String? get latestHeading {
     var sections = _parseSections();
-    return sections.firstOrNull?.title.substring(3).trim();
+    return sections.firstOrNull?.title.replaceAll(RegExp(r'^#*'), '').trim();
   }
 
   List<String> get latestChangeEntries {

--- a/pkgs/firehose/lib/src/changelog.dart
+++ b/pkgs/firehose/lib/src/changelog.dart
@@ -26,10 +26,7 @@ class Changelog {
 
     if (match != null) {
       var version = match.group(0);
-      print('Version: $version');
       return version;
-    } else {
-      print('No version number found.');
     }
     return null;
   }

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.15
+version: 0.3.16
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/test/changelog_test.dart
+++ b/pkgs/firehose/test/changelog_test.dart
@@ -17,11 +17,91 @@ void main() {
       });
     });
 
+    test('latestHeading', () {
+      withChangelog(_defaultContents, (file) {
+        var changelog = Changelog(file);
+        var heading = changelog.latestHeading;
+        expect(heading, '0.3.7+1');
+      });
+    });
+
+    test('Custom heading extraction', () {
+      withChangelog('''
+## 1.2.3+4 is the new version ## :) 
+''', (file) {
+        var changelog = Changelog(file);
+        var heading = changelog.latestHeading;
+        expect(heading, '1.2.3+4 is the new version ## :)');
+      });
+    });
+
     test('latestVersion', () {
       withChangelog(_defaultContents, (file) {
         var changelog = Changelog(file);
         var version = changelog.latestVersion;
-        expect(version, isNotNull);
+        expect(version, '0.3.7+1');
+      });
+    });
+
+    test('on digit version + x', () {
+      withChangelog('''
+## 1.2.3+4
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '1.2.3+4');
+      });
+    });
+
+    test('multi digit version + x', () {
+      withChangelog('''
+## 123.456.789+123456789
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '123.456.789+123456789');
+      });
+    });
+
+    test('no "+ x" at the end', () {
+      withChangelog('''
+## 123.456.789
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '123.456.789');
+      });
+    });
+
+    test('custom heading version', () {
+      withChangelog('''
+## [4.7.0](https://github.com/...) (2023-05-06)
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '4.7.0');
+      });
+    });
+
+    test('multiple versions mentioned', () {
+      withChangelog('''
+## [4.7.0](https://github.com/.../.../compare/v4.6.0...v4.7.0) (25.05.23)
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '4.7.0');
+      });
+    });
+
+    // This text will extract 25.05.23 which in fact
+    // is not the version. This heading order will fail
+    test('xx.xx.xx date format before version', () {
+      withChangelog('''
+## 25.05.23 [4.7.0](https://github.com/.../.../compare/v4.6.0...v4.7.0) 
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '25.05.23');
       });
     });
 
@@ -32,7 +112,7 @@ void main() {
 - mentioned here
 ''', (file) {
         var changelog = Changelog(file);
-        var version = changelog.latestVersion;
+        var version = changelog.latestHeading;
         expect(version, isNull);
       });
     });
@@ -40,7 +120,7 @@ void main() {
     test('no changelog file', () {
       var changelog = Changelog(File('missing_changelog.md'));
       expect(changelog.exists, false);
-      expect(changelog.latestVersion, isNull);
+      expect(changelog.latestHeading, isNull);
       expect(changelog.latestChangeEntries, isEmpty);
     });
 

--- a/pkgs/firehose/test/changelog_test.dart
+++ b/pkgs/firehose/test/changelog_test.dart
@@ -93,18 +93,6 @@ void main() {
       });
     });
 
-    // This text will extract 25.05.23 which in fact
-    // is not the version. This heading order will fail
-    test('xx.xx.xx date format before version', () {
-      withChangelog('''
-## 25.05.23 [4.7.0](https://github.com/.../.../compare/v4.6.0...v4.7.0) 
-''', (file) {
-        var changelog = Changelog(file);
-        var version = changelog.latestVersion;
-        expect(version, '25.05.23');
-      });
-    });
-
     test('missing versions', () {
       withChangelog('''
 - no
@@ -112,7 +100,7 @@ void main() {
 - mentioned here
 ''', (file) {
         var changelog = Changelog(file);
-        var version = changelog.latestHeading;
+        var version = changelog.latestVersion;
         expect(version, isNull);
       });
     });
@@ -120,7 +108,7 @@ void main() {
     test('no changelog file', () {
       var changelog = Changelog(File('missing_changelog.md'));
       expect(changelog.exists, false);
-      expect(changelog.latestHeading, isNull);
+      expect(changelog.latestVersion, isNull);
       expect(changelog.latestChangeEntries, isEmpty);
     });
 


### PR DESCRIPTION
- Fixes: #103
- Now checking if the changelog header is containing the version not if they equal, allowing for more custom header (e,g, using [release-please](https://github.com/googleapis/release-please))

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
