### PR TITLE
Allow prerelease suffix in CHANGELOG versions

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.17
+
+- Correctly parse pre-release versions from the CHANGELOG.
+
 ## 0.3.16
 
 - More robust version checking, now more diverse changelog formats are accepted.

--- a/pkgs/firehose/lib/src/changelog.dart
+++ b/pkgs/firehose/lib/src/changelog.dart
@@ -20,7 +20,7 @@ class Changelog {
       return null;
     }
 
-    final versionRegex = RegExp(r'[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?');
+    final versionRegex = RegExp(r'[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?(-\w+)?');
 
     var match = versionRegex.firstMatch(input);
 

--- a/pkgs/firehose/lib/src/changelog.dart
+++ b/pkgs/firehose/lib/src/changelog.dart
@@ -20,7 +20,7 @@ class Changelog {
       return null;
     }
 
-    final versionRegex = RegExp(r'[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?(-\w+)?');
+    final versionRegex = RegExp(r'[0-9]+\.[0-9]+\.[0-9]+([-\+]\w+)?');
 
     var match = versionRegex.firstMatch(input);
 

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.16
+version: 0.3.17
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/test/changelog_test.dart
+++ b/pkgs/firehose/test/changelog_test.dart
@@ -73,6 +73,16 @@ void main() {
       });
     });
 
+    test('with prerelease tag', () {
+      withChangelog('''
+## 123.456.789-wip
+''', (file) {
+        var changelog = Changelog(file);
+        var version = changelog.latestVersion;
+        expect(version, '123.456.789-wip');
+      });
+    });
+
     test('custom heading version', () {
       withChangelog('''
 ## [4.7.0](https://github.com/...) (2023-05-06)


### PR DESCRIPTION
Expand the regex to allow trailing suffixes like `-wip`. Add a test with
a `-wip` version.
