### PR TITLE
Make Changelog class eagerly load and parse file.

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 0.3.19
 - Clean-up and optimizations.
-- Stop depending on `package:collection` now that SDK 3.0.0 has `firstOrNull`.git
+- Stop depending on `package:collection` now that SDK 3.0.0 has `firstOrNull`.
 
 ## 0.3.18
 - Add Github workflow for PR health.

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,6 +1,9 @@
+## 0.3.20
+- Cache file contents and parsed data in `ChangeLog` class.
+
 ## 0.3.19
 - Clean-up and optimizations.
-- Stop depending on `package:collection` now that SDK 3.0.0 has `firstOrNull`.
+- Stop depending on `package:collection` now that SDK 3.0.0 has `firstOrNull`.git
 
 ## 0.3.18
 - Add Github workflow for PR health.

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.20
+## 0.3.20-wip
 - Cache file contents and parsed data in `ChangeLog` class.
 
 ## 0.3.19

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.19
+version: 0.3.20
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.20
+version: 0.3.20-wip
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
Rather than reading and parsing the file on each access, the class now eagerly reads the file in the constructor, and immediately parses it into sections.

Since the section parsing is incredibly simple, the overhead of splitting into sections should be minimal compared to loading the file from disk.
Also, the existing code read the entire file, even if it only needs the newest entry of the changelog, so parsing the entire file once and for all should not be significantly slower, and should be much faster on repeated access.

There should be no reason to create a Changelog and not query it at all.
