### PR TITLE
add environment input to support github deployment environments

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,12 @@ name: Publish
 on:
   workflow_call:
     inputs:
+      environment:
+        description: >-
+            If specified, the publish job (but not validate job) is required to
+            be run in this environment (with additional approvals).
+        required: false
+        type: string
       sdk:
         description: >-
           The channel, or a specific version from a channel, to install
@@ -40,7 +46,10 @@ on:
         type: string
 
 jobs:
-  publish:
+  # Note that this job does not require the specified environment.
+  validate:
+    if: ${{ github.event_name == 'pull_request' }}
+
     # These permissions are required for authentication using OIDC and to enable
     # us to create comments on PRs.
     permissions:
@@ -58,13 +67,31 @@ jobs:
         run: dart pub global activate firehose
 
       - name: Validate packages
-        if: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.number }}
           PR_LABELS: "${{ join(github.event.pull_request.labels.*.name) }}"
         run: dart pub global run firehose --validate
 
+  publish:
+    if: ${{ github.event_name == 'push' }}
+
+    # Require the github deployment environment if supplied.
+    environment: ${{ inputs.environment }}
+
+    # This permission is required for authentication using OIDC.
+    permissions:
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: ${{ inputs.sdk }}
+
+      - name: Install firehose
+        run: dart pub global activate firehose
+
       - name: Publish packages
-        if: ${{ github.event_name == 'push' }}
         run: dart pub global run firehose --publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,8 +32,10 @@ on:
     inputs:
       environment:
         description: >-
-            If specified, the publish job (but not validate job) is required to
-            be run in this environment (with additional approvals).
+            If specified, publishes will be performed from this environment,
+            which will require additional approvals. See
+            https://dart.dev/tools/pub/automated-publishing for more
+            information.
         required: false
         type: string
       sdk:
@@ -53,7 +55,6 @@ jobs:
     # These permissions are required for authentication using OIDC and to enable
     # us to create comments on PRs.
     permissions:
-      id-token: write
       pull-requests: write
 
     runs-on: ubuntu-latest

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.22-wip
+- Add docs for the new `environment` input to the publish action.
+
 ## 0.3.21
 - Allow empty coverage in PR health checks.
 

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -95,6 +95,26 @@ jobs:
       sdk: beta
 ```
 
+### Publishing from a protected Github environment
+
+Callers may optionally specify the name of a github environment for the publish
+job to use. This is useful if you want to require approvals for the publish job
+to run. To pass this value:
+
+```yaml
+jobs:
+  publish:
+    uses: dart-lang/ecosystem/.github/workflows/publish.yml@main
+    with:
+      environment: pub.dev # Can be any name, this is the convention though.
+```
+
+Make sure to also require this environment to be present in your package admin
+settings. See the [pub.dev documentation][github_environments] on this.
+
+
+[github_environments](https://dart.dev/tools/pub/automated-publishing#hardening-security-with-github-deployment-environments)
+
 ### Workflow docs
 
 The description of the common workflow for repos using this tool can be found at
@@ -135,7 +155,7 @@ jobs:
   health:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
 #   with:
-#     checks: "version,changelog,license,coverage" 
+#     checks: "version,changelog,license,coverage"
 ```
 
 ### Workflow docs

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -113,7 +113,7 @@ Make sure to also require this environment to be present in your package admin
 settings. See the [pub.dev documentation][github_environments] on this.
 
 
-[github_environments](https://dart.dev/tools/pub/automated-publishing#hardening-security-with-github-deployment-environments)
+[github_environments]: https://dart.dev/tools/pub/automated-publishing#hardening-security-with-github-deployment-environments
 
 ### Workflow docs
 

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.21
+version: 0.3.22-wip
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
Closes https://github.com/dart-lang/ecosystem/issues/130

Separates publish/validate into two different jobs. The publish job will use the supplied environment, which may require approvals to run the jobs if configured. See https://dart.dev/tools/pub/automated-publishing#hardening-security-with-github-deployment-environments.