### PR TITLE
Split commenting into new workflow

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -128,7 +128,7 @@ jobs:
       - name: Save PR number
         if: ${{ inputs.save_comment }}
         run: |
-          echo ${{ github.event.number }} > ./output/NR
+          echo ${{ github.event.number }} > ./output/issueNumber
 
       - name: Upload folder with number and markdown
         if: ${{ inputs.save_comment }}

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -128,7 +128,6 @@ jobs:
       - name: Save PR number
         if: ${{ inputs.save_comment }}
         run: |
-          mkdir -p ./pr
           echo ${{ github.event.number }} > ./output/NR
 
       - name: Upload folder with number and markdown

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -62,6 +62,11 @@ on:
         default: false
         type: boolean
         required: false
+      save_comment:
+        description: Whether to save summary as markdown file
+        default: false
+        type: boolean
+        required: false
 
 jobs:
   health:
@@ -102,7 +107,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.number }}
           PR_LABELS: "${{ join(github.event.pull_request.labels.*.name) }}"
-        run: cd current_repo/ && dart pub global run firehose:health --checks ${{ inputs.checks }} ${{ fromJSON('{"true":"--test_web","false":""}')[inputs.test_web] }}
+        run: cd current_repo/ && dart pub global run firehose:health --checks ${{ inputs.checks }} ${{ fromJSON('{"true":"--coverage_web","false":""}')[inputs.coverage_web] }}
 
       - name: Upload coverage to Coveralls
         if: ${{ inputs.upload_coverage }}
@@ -112,3 +117,23 @@ jobs:
           base-path: current_repo/
           compare-sha: ${{ github.event.pull_request.base.ref }}
           allow-empty: true
+
+      - name: Archive code coverage results
+        if: ${{ inputs.save_comment }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: output/${{ github.event.number }}/comment.md
+
+      - name: Save PR number
+        if: ${{ inputs.save_comment }}
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./output/NR
+
+      - name: Upload folder with number and markdown
+        if: ${{ inputs.save_comment }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: output
+          path: output/

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,0 +1,64 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Health"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "output"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/comment.zip', Buffer.from(download.data));
+      - run: unzip comment.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var markdown = fs.readFileSync('./comment.md');
+            if (fs.existsSync('./commentNumber')) {
+              var comment_number = Number(fs.readFileSync('./commentNumber'));
+              
+              await github.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment_number,
+                body: markdown
+              });
+            }
+            else{
+              var issue_number = Number(fs.readFileSync('./NR'));
+              
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: markdown
+              });
+            }

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -2,7 +2,7 @@ name: Comment on the pull request
 
 on:
   workflow_run:
-    workflows: ["Health"]
+    workflows: [Health]
     types:
       - completed
 

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,6 +1,8 @@
 name: Comment on the pull request
 
 on:
+  # Trigger this workflow after the Health workflow completes. This workflow will have permissions to
+  # do things like create comments on the PR, even if the original workflow couldn't.
   workflow_run:
     workflows: [Health]
     types:
@@ -13,8 +15,11 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
+
+      # Download the output of the health workflow, consisting of the comment markdown and either
+      # the issue number or an existing comment ID.
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@6f00a0b667f9463337970371ccda9072ee86fb27
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -35,8 +40,11 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/comment.zip', Buffer.from(download.data));
       - run: unzip comment.zip
 
+
+      # Create the comment, or update the existing one, with the markdown
+      # generated in the Health workflow.
       - name: 'Comment on PR'
-        uses: actions/github-script@v3
+        uses: actions/github-script@6f00a0b667f9463337970371ccda9072ee86fb27
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -53,7 +61,7 @@ jobs:
               });
             }
             else{
-              var issue_number = Number(fs.readFileSync('./NR'));
+              var issue_number = Number(fs.readFileSync('./issueNumber'));
 
               await github.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -42,8 +42,8 @@ jobs:
           script: |
             var fs = require('fs');
             var markdown = fs.readFileSync('./comment.md');
-            if (fs.existsSync('./commentNumber')) {
-              var comment_number = Number(fs.readFileSync('./commentNumber'));
+            if (fs.existsSync('./commentId')) {
+              var comment_number = Number(fs.readFileSync('./commentId'));
               
               await github.issues.updateComment({
                 owner: context.repo.owner,
@@ -54,7 +54,7 @@ jobs:
             }
             else{
               var issue_number = Number(fs.readFileSync('./NR'));
-              
+
               await github.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.24-wip
+- Start fixing [#137](https://github.com/dart-lang/ecosystem/issues/137).
+
 ## 0.3.23
 - Tweak PR health workflow.
 - Shorten some text in the markdown summary table.

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.24-wip
+## 0.3.24
 - Start fixing [#137](https://github.com/dart-lang/ecosystem/issues/137).
 
 ## 0.3.23

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -222,15 +222,18 @@ ${isWorseThanInfo ? 'This check can be disabled by tagging the PR with `skip-${r
       //   logError: print,
       // );
     } else {
-      await File('output/commentNumber')
-          .writeAsString(existingCommentId.toString());
+      var idFile = File('./output/commentId');
+      await idFile.create();
+      await idFile.writeAsString(existingCommentId.toString());
       // await allowFailure(
       //   github.updateComment(repoSlug, existingCommentId, summary),
       //   logError: print,
       // );
     }
 
-    await File('output/comment.md').writeAsString(summary);
+    var commentFile = File('./output/comment.md');
+    await commentFile.create();
+    await commentFile.writeAsString(summary);
 
     if (results.any((result) => result.severity == Severity.error) &&
         exitCode == 0) {

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -217,16 +217,20 @@ ${isWorseThanInfo ? 'This check can be disabled by tagging the PR with `skip-${r
     );
 
     if (existingCommentId == null) {
-      await allowFailure(
-        github.createComment(repoSlug, issueNumber, summary),
-        logError: print,
-      );
+      // await allowFailure(
+      //   github.createComment(repoSlug, issueNumber, summary),
+      //   logError: print,
+      // );
     } else {
-      await allowFailure(
-        github.updateComment(repoSlug, existingCommentId, summary),
-        logError: print,
-      );
+      await File('output/commentNumber')
+          .writeAsString(existingCommentId.toString());
+      // await allowFailure(
+      //   github.updateComment(repoSlug, existingCommentId, summary),
+      //   logError: print,
+      // );
     }
+
+    await File('output/comment.md').writeAsString(summary);
 
     if (results.any((result) => result.severity == Severity.error) &&
         exitCode == 0) {

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -223,7 +223,7 @@ ${isWorseThanInfo ? 'This check can be disabled by tagging the PR with `skip-${r
       // );
     } else {
       var idFile = File('./output/commentId');
-      await idFile.create();
+      await idFile.create(recursive: true);
       await idFile.writeAsString(existingCommentId.toString());
       // await allowFailure(
       //   github.updateComment(repoSlug, existingCommentId, summary),
@@ -232,7 +232,7 @@ ${isWorseThanInfo ? 'This check can be disabled by tagging the PR with `skip-${r
     }
 
     var commentFile = File('./output/comment.md');
-    await commentFile.create();
+    await commentFile.create(recursive: true);
     await commentFile.writeAsString(summary);
 
     if (results.any((result) => result.severity == Severity.error) &&

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -216,19 +216,10 @@ ${isWorseThanInfo ? 'This check can be disabled by tagging the PR with `skip-${r
       logError: print,
     );
 
-    if (existingCommentId == null) {
-      // await allowFailure(
-      //   github.createComment(repoSlug, issueNumber, summary),
-      //   logError: print,
-      // );
-    } else {
+    if (existingCommentId != null) {
       var idFile = File('./output/commentId');
       await idFile.create(recursive: true);
       await idFile.writeAsString(existingCommentId.toString());
-      // await allowFailure(
-      //   github.updateComment(repoSlug, existingCommentId, summary),
-      //   logError: print,
-      // );
     }
 
     var commentFile = File('./output/comment.md');

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.24-wip
+version: 0.3.24
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.23
+version: 0.3.24-wip
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
Fix #137, but as the `workflow_run` is only executed when on the main branch, testing this involves committing the workflow file.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
