### PR TITLE
Switch to Pub API

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.25
+
+- Switch to pub.dev API in `package:firehose`.
+
 ## 0.3.24
 
 - Fix [#137](https://github.com/dart-lang/ecosystem/issues/137).

--- a/pkgs/firehose/lib/src/pub.dart
+++ b/pkgs/firehose/lib/src/pub.dart
@@ -13,14 +13,16 @@ class Pub {
 
   Future<bool> hasPublishedVersion(String name, String version) async {
     var response =
-        await httpClient.get(Uri.parse('https://pub.dev/packages/$name.json'));
+        await httpClient.get(Uri.parse('https://pub.dev/api/packages/$name'));
     if (response.statusCode != 200) {
       return false;
     }
 
-    var json = jsonDecode(response.body) as Map;
-    var versions = json['versions'] as List;
-    return versions.contains(version);
+    var json = jsonDecode(response.body) as Map<String, dynamic>;
+    return (json['versions'] as List)
+        .map((versionObject) =>
+            (versionObject as Map<String, dynamic>)['version'])
+        .contains(version);
   }
 
   void close() {

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.24
+version: 0.3.25
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
An attempt to fix the exception in https://github.com/dart-lang/i18n/actions/runs/5802196156/job/16215135674, and also good in general to use the "official" API.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
