### PR TITLE
Pass a parameter for Flutter `firehose` support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -118,4 +118,4 @@ jobs:
         run: dart pub global activate firehose
 
       - name: Publish packages
-        run: dart pub global run firehose --publish
+        run: dart pub global run firehose --publish --use-flutter ${{ inputs.use_flutter }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ name: Publish
 #     with:
 #       sdk: beta
 
-# When using this package to publish Flutter packages, the `use_flutter`
+# When using this package to publish Flutter packages, the `use-flutter`
 # parameter should be set. The `sdk` parameter is then used to specify
 # the Flutter SDK.
 #
@@ -35,7 +35,7 @@ name: Publish
 #   publish:
 #     uses: dart-lang/ecosystem/.github/workflows/publish.yml@main
 #     with:
-#       use_flutter: true
+#       use-flutter: true
 
 on:
   workflow_call:
@@ -56,7 +56,7 @@ on:
         default: "stable"
         required: false
         type: string
-      use_flutter:
+      use-flutter:
         description: >-
           Whether to setup Flutter in this workflow.
         default: false
@@ -105,12 +105,12 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
 
       - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
-        if: ${{ inputs.use_flutter }}
+        if: ${{ inputs.use-flutter }}
         with:
           channel: ${{ inputs.sdk }}
 
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        if: ${{ !inputs.use_flutter }}
+        if: ${{ !inputs.use-flutter }}
         with:
           sdk: ${{ inputs.sdk }}
 
@@ -118,4 +118,4 @@ jobs:
         run: dart pub global activate firehose
 
       - name: Publish packages
-        run: dart pub global run firehose --publish --use-flutter ${{ inputs.use_flutter }}
+        run: dart pub global run firehose --publish --use-flutter ${{ inputs.use-flutter }}

--- a/pkgs/firehose/bin/firehose.dart
+++ b/pkgs/firehose/bin/firehose.dart
@@ -8,6 +8,10 @@ import 'package:args/args.dart';
 import 'package:firehose/firehose.dart';
 import 'package:firehose/src/github.dart';
 
+const validateOption = 'validate';
+const publishOption = 'publish';
+const useFlutterOption = 'use-flutter';
+
 void main(List<String> arguments) async {
   var argParser = _createArgs();
   try {
@@ -18,8 +22,9 @@ void main(List<String> arguments) async {
       exit(0);
     }
 
-    var validate = argResults['validate'] == true;
-    var publish = argResults['publish'] == true;
+    var validate = argResults[validateOption] == true;
+    var publish = argResults[publishOption] == true;
+    var useFlutter = argResults[useFlutterOption] == true;
 
     if (!validate && !publish) {
       _usage(argParser,
@@ -35,7 +40,7 @@ void main(List<String> arguments) async {
       exit(1);
     }
 
-    var firehose = Firehose(Directory.current);
+    var firehose = Firehose(Directory.current, useFlutter);
 
     if (validate) {
       await firehose.validate();
@@ -68,14 +73,19 @@ ArgParser _createArgs() {
       help: 'Print tool help.',
     )
     ..addFlag(
-      'validate',
+      validateOption,
       negatable: false,
       help: 'Validate packages and indicate whether --publish would publish '
           'anything.',
     )
     ..addFlag(
-      'publish',
+      publishOption,
       negatable: false,
       help: 'Publish any changed packages.',
+    )
+    ..addFlag(
+      useFlutterOption,
+      negatable: true,
+      help: 'Whether this is a Flutter project.',
     );
 }

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -23,8 +23,9 @@ const String _ignoreWarningsLabel = 'publish-ignore-warnings';
 
 class Firehose {
   final Directory directory;
+  final bool useFlutter;
 
-  Firehose(this.directory);
+  Firehose(this.directory, this.useFlutter);
 
   /// Validate the packages in the repository.
   ///
@@ -279,7 +280,7 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
     required bool force,
   }) async {
     String command;
-    if (package.pubspec.dependencies.containsKey('flutter')) {
+    if (useFlutter) {
       command = 'flutter';
     } else {
       command = 'dart';

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -73,7 +73,8 @@ class Health {
   }
 
   Future<HealthCheckResult> validateCheck(Github github) async {
-    var results = await Firehose(directory).verify(github);
+    //TODO: Add Flutter support for PR health checks
+    var results = await Firehose(directory, false).verify(github);
 
     var markdownTable = '''
 | Package | Version | Status |


### PR DESCRIPTION
Instead of detecting whether a package relies on Flutter by parsing the pubspec, let the user set this via a flag.

Pros:
- We need the flag anyhow to decide whether to setup Flutter in the first place
- Easy to implement and understand

Cons:
- The user has to set a flag for all packages in the repo

Alternatives:
- Run `dart pub get` and parse the `.dart_tool/package_config.json` "packages" key. I don't know if running `dart pub get` in a Flutter repo would have negative effects.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
