### PR TITLE
fix an issue rendering multi-line changelogs

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.29
+
+- Fix an issue rendering longer changelogs (#170).
+
 ## 0.3.28
 
 - Fix [#156](https://github.com/dart-lang/ecosystem/issues/156).

--- a/pkgs/firehose/lib/src/changelog.dart
+++ b/pkgs/firehose/lib/src/changelog.dart
@@ -85,7 +85,7 @@ class Changelog {
     return sections;
   }
 
-  String get describeLatestChanges => latestChangeEntries.join();
+  String get describeLatestChanges => latestChangeEntries.join('\n');
 }
 
 class _Section {

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.28
+version: 0.3.29
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:
@@ -20,5 +20,5 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.0.0
   test: ^1.21.0

--- a/pkgs/firehose/test/changelog_test.dart
+++ b/pkgs/firehose/test/changelog_test.dart
@@ -132,6 +132,16 @@ void main() {
       });
     });
 
+    test('describeLatestChanges', () {
+      withChangelog(_multiLineContents, (file) {
+        var changelog = Changelog(file);
+        var description = changelog.describeLatestChanges;
+        expect(description, '''
+- Fix issue 1.
+- Fix issue 2.''');
+      });
+    });
+
     test('no recent entries', () {
       withChangelog('''
 ## 0.2.0-dev
@@ -166,6 +176,17 @@ const _defaultContents = '''
 - Fix an issue in the `.github/workflows/publish.yaml` workflow file.
 
 ## 0.3.7
+
+- Provide feedback about publishing status as PR comments.
+''';
+
+const _multiLineContents = '''
+## 0.3.6
+
+- Fix issue 1.
+- Fix issue 2.
+
+## 0.3.5
 
 - Provide feedback about publishing status as PR comments.
 ''';


### PR DESCRIPTION
- fix an issue rendering multi-line changelogs in the pre-populated github release text
- fix https://github.com/dart-lang/ecosystem/issues/170

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
