### PR TITLE
Simplify dart_flutter_team_lints install instructions

### DIFF
--- a/pkgs/dart_flutter_team_lints/README.md
+++ b/pkgs/dart_flutter_team_lints/README.md
@@ -12,7 +12,7 @@ wider ecosystem. For our community recommendations, see `package:lints` and
 `package:flutter_lints`.
 
 For documentation about customizing static analysis for your project, see
-https://dart.dev/guides/language/analysis-options.
+https://dart.dev/tools/analysis.
 
 ## Using the Lints
 

--- a/pkgs/dart_flutter_team_lints/README.md
+++ b/pkgs/dart_flutter_team_lints/README.md
@@ -16,11 +16,11 @@ https://dart.dev/guides/language/analysis-options.
 
 ## Using the Lints
 
-To use the lints, add a dependency in your `pubspec.yaml` file:
+To use the lints, add the package as a dev dependency
+in your `pubspec.yaml` file:
 
-```yaml
-dev_dependencies:
-  dart_flutter_team_lints: ^1.0.0
+```bash
+dart pub add dev:dart_flutter_team_lints
 ```
 
 then, add an `analysis_options.yaml` file to your project:

--- a/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
@@ -11,7 +11,7 @@
 # and `package:flutter_lints`.
 #
 # For documentation about customizing static analysis for your project, see
-# https://dart.dev/guides/language/analysis-options.
+# https://dart.dev/tools/analysis.
 
 include: package:lints/recommended.yaml
 


### PR DESCRIPTION
Since 2.0.0 came out, this text was outdated. Suggest using `dart pub add` instead.