### PR TITLE
improve support for '-dev' and '-wip' package versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ name: Publish
 #     branches: [ main ]
 #     types: [opened, synchronize, reopened, labeled, unlabeled]
 #   push:
-#     tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
+#     tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
 # jobs:
 #   publish:
 #     uses: dart-lang/ecosystem/.github/workflows/publish.yml@main

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
-    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 env:
   use-flutter: false

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.30-wip
+## 0.3.30-dev
 
 - Improve support for `-dev` and `-wip` package versions.
 

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.30-wip
+
+- Improve support for `-dev` and `-wip` package versions.
+
 ## 0.3.29
 
 - Fix an issue rendering longer changelogs (#170).

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.30-dev
+## 0.3.30
 
 - Improve support for `-dev` and `-wip` package versions.
 

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -139,8 +139,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
         print(result);
         results.addResult(result);
       } else if (package.pubspec.version!.wip) {
-        var result =
-            Result.info(package, 'pre-release WIP (no publish necessary)');
+        var result = Result.info(package, 'WIP (no publish necessary)');
         print(result);
         results.addResult(result);
       } else {

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -138,11 +138,9 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
         var result = Result.info(package, 'already published at pub.dev');
         print(result);
         results.addResult(result);
-      } else if (package.pubspec.version!.isPreRelease) {
-        var result = Result.info(
-          package,
-          'pre-release version (no publish necessary)',
-        );
+      } else if (package.pubspec.version!.wip) {
+        var result =
+            Result.info(package, 'pre-release WIP (no publish necessary)');
         print(result);
         results.addResult(result);
       } else {

--- a/pkgs/firehose/lib/src/pub.dart
+++ b/pkgs/firehose/lib/src/pub.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:pub_semver/pub_semver.dart';
 
 class Pub {
   http.Client? _httpClient;
@@ -27,5 +28,11 @@ class Pub {
 
   void close() {
     _httpClient?.close();
+  }
+}
+
+extension VersionExtension on Version {
+  bool get wip {
+    return isPreRelease && preRelease.length == 1 && preRelease.first == 'wip';
   }
 }

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.29
+version: 0.3.30-wip
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.30-dev
+version: 0.3.30
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.30-wip
+version: 0.3.30-dev
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/test/pub_test.dart
+++ b/pkgs/firehose/test/pub_test.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'package:firehose/src/pub.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -33,6 +34,23 @@ void main() {
       var result = await pub.hasPublishedVersion(
           'foo_bar_not_published_package', '1.8.0');
       expect(result, false);
+    });
+  });
+
+  group('VersionExtension', () {
+    test('wip no pre-release', () async {
+      final version = Version.parse('1.2.3');
+      expect(version.wip, false);
+    });
+
+    test('wip pre-release', () async {
+      final version = Version.parse('1.2.3-dev');
+      expect(version.wip, false);
+    });
+
+    test('wip pre-release wip', () async {
+      final version = Version.parse('1.2.3-wip');
+      expect(version.wip, true);
     });
   });
 }


### PR DESCRIPTION
- improve support for '-dev' and '-wip' package versions

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
