### PR TITLE
Allow both single-workflow and fork-enabled publishing validation

### DIFF
--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -6,6 +6,7 @@ on:
   workflow_call:
   workflow_run:
     workflows:
+      - Publish
       - Health
     types:
       - completed

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -6,7 +6,6 @@ on:
   workflow_call:
   workflow_run:
     workflows:
-      - Publish
       - Health
     types:
       - completed

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,6 +62,12 @@ on:
         default: false
         required: false
         type: boolean
+      write-comments:
+        description: >-
+          Whether to write a comment in this workflow.
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   # Note that this job does not require the specified environment.
@@ -97,6 +103,7 @@ jobs:
         run: dart pub global run firehose --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }}
 
       - name: Get comment id
+        if: ${{ inputs.write-comments }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -104,23 +111,27 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.COMMENT_ID == '' }}
+        if: ${{ inputs.write-comments }} && ${{ env.COMMENT_ID == '' }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
+          edit-mode: replace
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.COMMENT_ID != '' }}
+        if: ${{ inputs.write-comments }} && ${{ env.COMMENT_ID != '' }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
+          edit-mode: replace
 
       - name: Save PR number
+        if: ${{ !inputs.write-comments }}
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
 
       - name: Upload folder with number and markdown
+        if: ${{ !inputs.write-comments }}
         uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: output

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -103,7 +103,7 @@ jobs:
         run: dart pub global run firehose --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }}
 
       - name: Get comment id
-        if: ${{ inputs.write-comments }}
+        if: ${{ env.write-comments == true }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ inputs.write-comments && env.COMMENT_ID == '' }}
+        if: ${{ (env.write-comments == true) && (env.COMMENT_ID == '') }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -119,19 +119,19 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ inputs.write-comments && env.COMMENT_ID != '' }}
+        if: ${{ (env.write-comments == true) && (env.COMMENT_ID != '') }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
           edit-mode: replace
 
       - name: Save PR number
-        if: ${{ !inputs.write-comments }}
+        if: ${{ env.write-comments == false }}
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
 
       - name: Upload folder with number and markdown
-        if: ${{ !inputs.write-comments }}
+        if: ${{ env.write-comments == false }}
         uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: output

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -103,7 +103,7 @@ jobs:
         run: dart pub global run firehose --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }}
 
       - name: Get comment id
-        if: ${{ env.write-comments == true }}
+        if: ${{ inputs.write-comments }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ (env.write-comments == true) && (env.COMMENT_ID == '') }}
+        if: ${{ inputs.write-comments && (env.COMMENT_ID == '') }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -119,19 +119,19 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ (env.write-comments == true) && (env.COMMENT_ID != '') }}
+        if: ${{ inputs.write-comments && (env.COMMENT_ID != '') }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
           edit-mode: replace
 
       - name: Save PR number
-        if: ${{ env.write-comments == false }}
+        if: ${{ !inputs.write-comments }}
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
 
       - name: Upload folder with number and markdown
-        if: ${{ env.write-comments == false }}
+        if: ${{ !inputs.write-comments }}
         uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: output

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ inputs.write-comments }} && ${{ env.COMMENT_ID == '' }}
+        if: ${{ inputs.write-comments && env.COMMENT_ID == '' }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -119,7 +119,7 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ inputs.write-comments }} && ${{ env.COMMENT_ID != '' }}
+        if: ${{ inputs.write-comments && env.COMMENT_ID != '' }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -103,7 +103,7 @@ jobs:
         run: dart pub global run firehose --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }}
 
       - name: Get comment id
-        if: ${{ inputs.write-comments }}
+        if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ inputs.write-comments && (env.COMMENT_ID == '') }}
+        if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (env.COMMENT_ID == '') }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -119,7 +119,7 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ inputs.write-comments && (env.COMMENT_ID != '') }}
+        if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (env.COMMENT_ID != '') }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,6 +96,26 @@ jobs:
           PR_LABELS: "${{ join(github.event.pull_request.labels.*.name) }}"
         run: dart pub global run firehose --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }}
 
+      - name: Get comment id
+        run: |
+          touch -a output/commentId
+          COMMENT_ID=$(cat output/commentId)
+          echo "COMMENT_ID=$COMMENT_ID" >> $GITHUB_ENV
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
+        if: ${{ env.COMMENT_ID == '' }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-path: 'output/comment.md'
+
+      - name: Update comment
+        uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
+        if: ${{ env.COMMENT_ID != '' }}
+        with:
+          comment-id: ${{ env.COMMENT_ID }}
+          body-path: 'output/comment.md'
+
       - name: Save PR number
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,6 +37,15 @@ name: Publish
 #     with:
 #       use-flutter: true
 
+# When using a post_summaries.yaml workflow to post the comments, set
+# the write-comments parameter to false.
+#
+# jobs:
+#   publish:
+#     uses: dart-lang/ecosystem/.github/workflows/publish.yml@main
+#     with:
+#       write-comments: false
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -44,7 +44,7 @@ jobs:
         run: dart pkgs/firehose/bin/firehose.dart --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[env.use-flutter] }}
 
       - name: Get comment id
-        if: ${{ env.write-comments }}
+        if: ${{ env.write-comments == true }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.write-comments && env.COMMENT_ID == '' }}
+        if: ${{ (env.write-comments == true) && (env.COMMENT_ID == '') }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -60,19 +60,19 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.write-comments && env.COMMENT_ID != '' }}
+        if: ${{ (env.write-comments == true) && (env.COMMENT_ID != '') }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
           edit-mode: replace
 
       - name: Save PR number
-        if: ${{ !env.write-comments }}
+        if: ${{ env.write-comments == false }}
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
 
       - name: Upload folder with number and markdown
-        if: ${{ !env.write-comments }}
+        if: ${{ env.write-comments == false }}
         uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: output

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -14,6 +14,7 @@ on:
 
 env:
   use-flutter: false
+  write-comments: true
 
 jobs:
   publish:
@@ -43,6 +44,7 @@ jobs:
         run: dart pkgs/firehose/bin/firehose.dart --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[env.use-flutter] }}
 
       - name: Get comment id
+        if: ${{ env.write-comments }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -50,7 +52,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.COMMENT_ID == '' }}
+        if: ${{ env.write-comments }} && ${{ env.COMMENT_ID == '' }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -58,17 +60,19 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.COMMENT_ID != '' }}
+        if: ${{ env.write-comments }} && ${{ env.COMMENT_ID != '' }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
           edit-mode: replace
 
       - name: Save PR number
+        if: ${{ !env.write-comments }}
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
 
       - name: Upload folder with number and markdown
+        if: ${{ !env.write-comments }}
         uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: output

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   publish:
-    if: github.repository_owner == 'dart-lang'
+    if: github.repository_owner == 'mosuem'
 
     # These permissions are required for authentication using OIDC and to enable
     # us to create comments on PRs.

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -13,8 +13,8 @@ on:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 env:
-  use-flutter: false
-  write-comments: false
+  use-flutter:  ${{ false }}
+  write-comments:  ${{ false }}
 
 jobs:
   publish:

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -54,6 +54,7 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
+          edit-mode: replace
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
@@ -61,6 +62,7 @@ jobs:
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
+          edit-mode: replace
 
       - name: Save PR number
         run: |

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   use-flutter: false
-  write-comments: true
+  write-comments: false
 
 jobs:
   publish:

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.write-comments }} && ${{ env.COMMENT_ID == '' }}
+        if: ${{ env.write-comments && env.COMMENT_ID == '' }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ env.write-comments }} && ${{ env.COMMENT_ID != '' }}
+        if: ${{ env.write-comments && env.COMMENT_ID != '' }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -44,7 +44,7 @@ jobs:
         run: dart pkgs/firehose/bin/firehose.dart --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[env.use-flutter] }}
 
       - name: Get comment id
-        if: ${{ env.write-comments == true }}
+        if: ${{ fromJSON(env.write-comments ) }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ (env.write-comments == true) && (env.COMMENT_ID == '') }}
+        if: ${{ fromJSON(env.write-comments ) && (env.COMMENT_ID == '') }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -60,19 +60,19 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ (env.write-comments == true) && (env.COMMENT_ID != '') }}
+        if: ${{ fromJSON(env.write-comments ) && (env.COMMENT_ID != '') }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'
           edit-mode: replace
 
       - name: Save PR number
-        if: ${{ env.write-comments == false }}
+        if: ${{ !fromJSON(env.write-comments ) }}
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
 
       - name: Upload folder with number and markdown
-        if: ${{ env.write-comments == false }}
+        if: ${{ !fromJSON(env.write-comments ) }}
         uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: output

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -42,6 +42,26 @@ jobs:
           PR_LABELS: "${{ join(github.event.pull_request.labels.*.name) }}"
         run: dart pkgs/firehose/bin/firehose.dart --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[env.use-flutter] }}
 
+      - name: Get comment id
+        run: |
+          touch -a output/commentId
+          COMMENT_ID=$(cat output/commentId)
+          echo "COMMENT_ID=$COMMENT_ID" >> $GITHUB_ENV
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
+        if: ${{ env.COMMENT_ID == '' }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-path: 'output/comment.md'
+
+      - name: Update comment
+        uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
+        if: ${{ env.COMMENT_ID != '' }}
+        with:
+          comment-id: ${{ env.COMMENT_ID }}
+          body-path: 'output/comment.md'
+
       - name: Save PR number
         run: |
           mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -14,11 +14,11 @@ on:
 
 env:
   use-flutter:  ${{ false }}
-  write-comments:  ${{ false }}
+  write-comments:  ${{ true }}
 
 jobs:
   publish:
-    if: github.repository_owner == 'mosuem'
+    if: github.repository_owner == 'dart-lang'
 
     # These permissions are required for authentication using OIDC and to enable
     # us to create comments on PRs.

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -13,8 +13,8 @@ on:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 env:
-  use-flutter:  ${{ false }}
-  write-comments:  ${{ true }}
+  use-flutter: false
+  write-comments: true
 
 jobs:
   publish:

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -44,7 +44,7 @@ jobs:
         run: dart pkgs/firehose/bin/firehose.dart --validate ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[env.use-flutter] }}
 
       - name: Get comment id
-        if: ${{ fromJSON(env.write-comments ) }}
+        if: ${{ (hashFiles('output/comment.md') != '') && fromJSON(env.write-comments ) }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ fromJSON(env.write-comments ) && (env.COMMENT_ID == '') }}
+        if: ${{ (hashFiles('output/comment.md') != '') && fromJSON(env.write-comments ) && (env.COMMENT_ID == '') }}
         with:
           issue-number: ${{ github.event.number }}
           body-path: 'output/comment.md'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@46da6c0d98504aed6fc429519a258b951f23f474
-        if: ${{ fromJSON(env.write-comments ) && (env.COMMENT_ID != '') }}
+        if: ${{ (hashFiles('output/comment.md') != '') && fromJSON(env.write-comments ) && (env.COMMENT_ID != '') }}
         with:
           comment-id: ${{ env.COMMENT_ID }}
           body-path: 'output/comment.md'

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -79,6 +79,34 @@ jobs:
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
 ```
 
+#### Enabling comments on forks
+
+- add the following to your `publish.yaml`:
+```yaml
+with:
+       write-comments: false
+``` 
+- copy the yaml below into a `.github/workflows/post_summaries.yaml` file in your repo
+
+```yaml
+# A CI configuration to write comments on PRs.
+
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: 
+      - Publish
+    types:
+      - completed
+
+jobs:
+  upload:
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    permissions:
+      pull-requests: write
+```
+
 ### Publishing from a specific version of the SDK
 
 Callers may optionally specify the version of the SDK to use when publishing a


### PR DESCRIPTION
Make writing a comment from just the `publish.yaml` workflow the default, but allow an option to use a `post_summaries.yaml`-type setup instead.

Fixes #175.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
