### PR TITLE
Add `run-before` argument to `publish.yaml`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,6 +77,12 @@ on:
         default: true
         required: false
         type: boolean
+      run-before:
+        description: >-
+          Arbitrary command to run before running 
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   # Note that this job does not require the specified environment.
@@ -103,6 +109,10 @@ jobs:
 
       - name: Install firehose
         run: dart pub global activate firehose
+
+      - name: Run custom command
+        run: ${{ inputs.run-before }}
+        if: ${{ inputs.run-before != '' }}
 
       - name: Validate packages
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -80,9 +80,9 @@ on:
       run-before:
         description: >-
           Arbitrary command to run before running 
-        default: true
+        default: ''
         required: false
-        type: boolean
+        type: string
 
 jobs:
   # Note that this job does not require the specified environment.

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -15,6 +15,7 @@ on:
 env:
   use-flutter: false
   write-comments: false
+  run-before: echo Hi
 
 jobs:
   publish:
@@ -34,6 +35,10 @@ jobs:
       - name: Pub get
         working-directory: pkgs/firehose
         run: dart pub get
+
+      - name: Run custom command
+        run: ${{ env.run-before }}
+        if: ${{ env.run-before != '' }}
 
       - name: Validate packages
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -15,7 +15,7 @@ on:
 env:
   use-flutter: false
   write-comments: false
-  run-before: echo Hi
+  run-before: ''
 
 jobs:
   publish:


### PR DESCRIPTION
To give the ability to run custom commands, such as building or deleting resources or running custom testing code, before running the actual publishing workflow.

See https://github.com/google/protobuf.dart/actions/runs/6650962761/job/18072032295 and the necessity to run `make protos` to not have `dart analyze` fail.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
