### PR TITLE
add PR stats to the 'bin/report.dart weekly' command

### DIFF
--- a/pkgs/repo_manage/lib/issue_transfer.dart
+++ b/pkgs/repo_manage/lib/issue_transfer.dart
@@ -39,7 +39,7 @@ class TransferIssuesCommand extends ReportCommand {
     argParser.addOption(
       'add-label',
       help: 'Add a label to all transferred issues.',
-      valueHelp: 'pkg:foo',
+      valueHelp: 'package:foo',
     );
   }
 

--- a/pkgs/repo_manage/lib/src/common.dart
+++ b/pkgs/repo_manage/lib/src/common.dart
@@ -126,6 +126,7 @@ class RepoInfo {
   final String repo;
   final int issuesOpened;
   final int issuesClosed;
+  final int prsOpened;
   final int commits;
   final int p0Count;
   final int p1Count;
@@ -135,6 +136,7 @@ class RepoInfo {
     this.repo, {
     required this.issuesOpened,
     required this.issuesClosed,
+    required this.prsOpened,
     required this.commits,
     required this.p0Count,
     required this.p1Count,


### PR DESCRIPTION
- add PR stats to the 'bin/report.dart weekly' command

An interesting stat - we had ~800 PRs opened on dart-lang repos last month.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
