### PR TITLE
Add retries to `pub.dev/api/` calls

### DIFF
--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -17,8 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.event == 'pull_request'
     continue-on-error: true
     steps:
 

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.33
+
+- Retry calls to pub.dev API.
+
 ## 0.3.32
 
 - Fix an issue validating pre-release git publishing tags (#176).

--- a/pkgs/firehose/lib/src/pub.dart
+++ b/pkgs/firehose/lib/src/pub.dart
@@ -13,8 +13,8 @@ class Pub {
   http.Client get httpClient => _httpClient ??= http.Client();
 
   Future<bool> hasPublishedVersion(String name, String version) async {
-    var response =
-        await httpClient.get(Uri.parse('https://pub.dev/api/packages/$name'));
+    var uri = Uri.parse('https://pub.dev/api/packages/$name');
+    http.Response response = await getCall(uri, retries: 3);
     if (response.statusCode != 200) {
       return false;
     }
@@ -24,6 +24,20 @@ class Pub {
         .map((versionObject) =>
             (versionObject as Map<String, dynamic>)['version'])
         .contains(version);
+  }
+
+  Future<http.Response> getCall(Uri uri, {required int retries}) async {
+    for (var i = 0; i < retries + 1; i++) {
+      try {
+        var response = await httpClient.get(uri);
+        return response;
+      } catch (e) {
+        if (i >= retries) {
+          rethrow;
+        }
+      }
+    }
+    throw AssertionError('This should be unreachable');
   }
 
   void close() {

--- a/pkgs/firehose/lib/src/pub.dart
+++ b/pkgs/firehose/lib/src/pub.dart
@@ -14,7 +14,7 @@ class Pub {
 
   Future<bool> hasPublishedVersion(String name, String version) async {
     var uri = Uri.parse('https://pub.dev/api/packages/$name');
-    http.Response response = await getCall(uri, retries: 3);
+    var response = await getCall(uri, retries: 3);
     if (response.statusCode != 200) {
       return false;
     }

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.3.32
+version: 0.3.33
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
Trying to fix CI issues such as https://github.com/dart-lang/i18n/actions/runs/6927812726/job/18894419545. See also internal https://chat.google.com/room/AAAAkQUOtE8/Hgl4bXnbkOs.

Also sneaking in a small change to the commenting workflow.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
