### PR TITLE
Use Flutter in `health.yaml`

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -62,6 +62,12 @@ on:
         default: false
         type: boolean
         required: false
+      use-flutter:
+        description: >-
+          Whether to setup Flutter in this workflow.
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   health:
@@ -81,7 +87,13 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           path: base_repo/
           
+      - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
+        if: ${{ inputs.use-flutter }}
+        with:
+          channel: ${{ inputs.sdk }}
+  
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        if: ${{ !inputs.use-flutter }}
         with:
           sdk: ${{ inputs.sdk }}
 


### PR DESCRIPTION
To allow `health.yaml` to work for packages using Flutter, for example `package:jni`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
