### PR TITLE
De-async health checks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "health",
+            "program": "pkgs/firehose/bin/health.dart",
+            "request": "launch",
+            "type": "dart",
+            "env": {
+                "GITHUB_REPOSITORY": "dart-lang/ecosystem",
+                "ISSUE_NUMBER": "173",
+                "GITHUB_SHA": "null",
+                "GITHUB_STEP_SUMMARY": "/tmp/github_step_summary_mock.md",
+            },
+            "args": [
+                "--checks",
+                "version,changelog,license,coverage,do-not-submit"
+            ]
+        }
+    ]
+}

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.4.1-wip
+## 0.4.1
 
 - Ensure that packages are listed in lexical order.
 - Require the latest `package:http`.
+- Delay Github requests by a small delay to avoid http errors.
 
 ## 0.4.0
 

--- a/pkgs/firehose/lib/src/delayed_client.dart
+++ b/pkgs/firehose/lib/src/delayed_client.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+class DelayedClient implements http.Client {
+  final http.Client _client;
+
+  factory DelayedClient() => DelayedClient._(client: http.Client());
+
+  DelayedClient._({required http.Client client}) : _client = client;
+
+  @override
+  void close() => _client.close();
+
+  @override
+  Future<http.Response> delete(Uri url,
+          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
+      Future.delayed(
+          const Duration(seconds: 1),
+          () => _client.delete(url,
+              body: body, encoding: encoding, headers: headers));
+
+  @override
+  Future<http.Response> get(Uri url, {Map<String, String>? headers}) =>
+      Future.delayed(
+          const Duration(seconds: 1), () => _client.get(url, headers: headers));
+
+  @override
+  Future<http.Response> head(Uri url, {Map<String, String>? headers}) =>
+      Future.delayed(const Duration(seconds: 1),
+          () => _client.head(url, headers: headers));
+
+  @override
+  Future<http.Response> patch(Uri url,
+          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
+      Future.delayed(
+          const Duration(seconds: 1),
+          () => _client.patch(url,
+              headers: headers, body: body, encoding: encoding));
+
+  @override
+  Future<http.Response> post(Uri url,
+          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
+      Future.delayed(
+          const Duration(seconds: 1),
+          () => _client.post(url,
+              headers: headers, body: body, encoding: encoding));
+  @override
+  Future<http.Response> put(Uri url,
+          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
+      Future.delayed(
+          const Duration(seconds: 1),
+          () => _client.put(url,
+              headers: headers, body: body, encoding: encoding));
+  @override
+  Future<String> read(Uri url, {Map<String, String>? headers}) =>
+      Future.delayed(const Duration(seconds: 1),
+          () => _client.read(url, headers: headers));
+
+  @override
+  Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) =>
+      Future.delayed(const Duration(seconds: 1),
+          () => _client.readBytes(url, headers: headers));
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) =>
+      Future.delayed(const Duration(seconds: 1), () => _client.send(request));
+}

--- a/pkgs/firehose/lib/src/delayed_client.dart
+++ b/pkgs/firehose/lib/src/delayed_client.dart
@@ -6,10 +6,15 @@ import 'package:http/http.dart' as http;
 
 class DelayedClient implements http.Client {
   final http.Client _client;
+  final Duration duration;
 
-  factory DelayedClient() => DelayedClient._(client: http.Client());
+  factory DelayedClient(Duration duration) => DelayedClient._(
+        client: http.Client(),
+        duration: duration,
+      );
 
-  DelayedClient._({required http.Client client}) : _client = client;
+  DelayedClient._({required this.duration, required http.Client client})
+      : _client = client;
 
   @override
   void close() => _client.close();
@@ -18,25 +23,23 @@ class DelayedClient implements http.Client {
   Future<http.Response> delete(Uri url,
           {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
       Future.delayed(
-          const Duration(seconds: 1),
+          duration,
           () => _client.delete(url,
               body: body, encoding: encoding, headers: headers));
 
   @override
   Future<http.Response> get(Uri url, {Map<String, String>? headers}) =>
-      Future.delayed(
-          const Duration(seconds: 1), () => _client.get(url, headers: headers));
+      Future.delayed(duration, () => _client.get(url, headers: headers));
 
   @override
   Future<http.Response> head(Uri url, {Map<String, String>? headers}) =>
-      Future.delayed(const Duration(seconds: 1),
-          () => _client.head(url, headers: headers));
+      Future.delayed(duration, () => _client.head(url, headers: headers));
 
   @override
   Future<http.Response> patch(Uri url,
           {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
       Future.delayed(
-          const Duration(seconds: 1),
+          duration,
           () => _client.patch(url,
               headers: headers, body: body, encoding: encoding));
 
@@ -44,27 +47,25 @@ class DelayedClient implements http.Client {
   Future<http.Response> post(Uri url,
           {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
       Future.delayed(
-          const Duration(seconds: 1),
+          duration,
           () => _client.post(url,
               headers: headers, body: body, encoding: encoding));
   @override
   Future<http.Response> put(Uri url,
           {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
       Future.delayed(
-          const Duration(seconds: 1),
+          duration,
           () => _client.put(url,
               headers: headers, body: body, encoding: encoding));
   @override
   Future<String> read(Uri url, {Map<String, String>? headers}) =>
-      Future.delayed(const Duration(seconds: 1),
-          () => _client.read(url, headers: headers));
+      Future.delayed(duration, () => _client.read(url, headers: headers));
 
   @override
   Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) =>
-      Future.delayed(const Duration(seconds: 1),
-          () => _client.readBytes(url, headers: headers));
+      Future.delayed(duration, () => _client.readBytes(url, headers: headers));
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) =>
-      Future.delayed(const Duration(seconds: 1), () => _client.send(request));
+      Future.delayed(duration, () => _client.send(request));
 }

--- a/pkgs/firehose/lib/src/delayed_client.dart
+++ b/pkgs/firehose/lib/src/delayed_client.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:convert';
 
 import 'dart:typed_data';

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -26,14 +26,14 @@ class GithubApi {
       : _repoSlug = repoSlug,
         _issueNumber = issueNumber;
 
-  final http.Client client = DelayedClient(const Duration(milliseconds: 50));
+  final http.Client _client = DelayedClient(const Duration(milliseconds: 50));
 
   late GitHub github = githubAuthToken != null
       ? GitHub(
           auth: Authentication.withToken(githubAuthToken),
-          client: client,
+          client: _client,
         )
-      : GitHub(client: client);
+      : GitHub(client: _client);
 
   String? get githubAuthToken => _env['GITHUB_TOKEN'];
 

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -6,9 +6,9 @@
 import 'dart:io';
 
 import 'package:github/github.dart';
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
-import 'delayed_client.dart';
 import 'repo.dart';
 
 class GithubApi {
@@ -25,7 +25,7 @@ class GithubApi {
       : _repoSlug = repoSlug,
         _issueNumber = issueNumber;
 
-  final DelayedClient client = DelayedClient();
+  final http.Client client = http.Client();
 
   late GitHub github = githubAuthToken != null
       ? GitHub(

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -9,6 +9,7 @@ import 'package:github/github.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
+import 'delayed_client.dart';
 import 'repo.dart';
 
 class GithubApi {
@@ -25,7 +26,7 @@ class GithubApi {
       : _repoSlug = repoSlug,
         _issueNumber = issueNumber;
 
-  final http.Client client = http.Client();
+  final http.Client client = DelayedClient(const Duration(milliseconds: 50));
 
   late GitHub github = githubAuthToken != null
       ? GitHub(

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:github/github.dart';
 import 'package:path/path.dart' as path;
 
+import 'delayed_client.dart';
 import 'repo.dart';
 
 class GithubApi {
@@ -24,9 +25,14 @@ class GithubApi {
       : _repoSlug = repoSlug,
         _issueNumber = issueNumber;
 
+  final DelayedClient client = DelayedClient();
+
   late GitHub github = githubAuthToken != null
-      ? GitHub(auth: Authentication.withToken(githubAuthToken))
-      : GitHub();
+      ? GitHub(
+          auth: Authentication.withToken(githubAuthToken),
+          client: client,
+        )
+      : GitHub(client: client);
 
   String? get githubAuthToken => _env['GITHUB_TOKEN'];
 

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -47,7 +47,6 @@ class Health {
     var github = GithubApi();
 
     // Do basic validation of our expected env var.
-    if (!expectEnv(github.githubAuthToken, 'GITHUB_TOKEN')) return;
     if (!expectEnv(github.repoSlug?.fullName, 'GITHUB_REPOSITORY')) return;
     if (!expectEnv(github.issueNumber?.toString(), 'ISSUE_NUMBER')) return;
     if (!expectEnv(github.sha, 'GITHUB_SHA')) return;
@@ -78,10 +77,11 @@ class Health {
           !github.prLabels.contains('skip-do-not-submit-check'))
         doNotSubmitCheck,
     ];
-
-    var checked =
-        await Future.wait(checks.map((check) => check(github)).toList());
-    await writeInComment(github, checked);
+    final results = <HealthCheckResult>[];
+    for (var check in checks) {
+      results.add(await check(github));
+    }
+    await writeInComment(github, results);
   }
 
   Future<HealthCheckResult> validateCheck(GithubApi github) async {

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -77,18 +77,11 @@ class Health {
           !github.prLabels.contains('skip-do-not-submit-check'))
         doNotSubmitCheck,
     ];
-    try {
-      final results = <HealthCheckResult>[];
-      for (var check in checks) {
-        results.add(await check(github));
-      }
-      await writeInComment(github, results);
-    } catch (e) {
-      print(e);
-      print(
-          '${github.github.rateLimitRemaining} ${github.github.rateLimitReset}');
-      rethrow;
+    final results = <HealthCheckResult>[];
+    for (var check in checks) {
+      results.add(await check(github));
     }
+    await writeInComment(github, results);
   }
 
   Future<HealthCheckResult> validateCheck(GithubApi github) async {

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -77,11 +77,18 @@ class Health {
           !github.prLabels.contains('skip-do-not-submit-check'))
         doNotSubmitCheck,
     ];
-    final results = <HealthCheckResult>[];
-    for (var check in checks) {
-      results.add(await check(github));
+    try {
+      final results = <HealthCheckResult>[];
+      for (var check in checks) {
+        results.add(await check(github));
+      }
+      await writeInComment(github, results);
+    } catch (e) {
+      print(e);
+      print(
+          '${github.github.rateLimitRemaining} ${github.github.rateLimitReset}');
+      rethrow;
     }
-    await writeInComment(github, results);
   }
 
   Future<HealthCheckResult> validateCheck(GithubApi github) async {

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.4.1-wip
+version: 0.4.1
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
- Execute the health checks one-by-one instead of all at the same time for easier debugging
- Add a small delay to all http requests, this seems to resolve the Github API issues.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
