### PR TITLE
fix saving of comment ids to disk

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.1
 
-- Fix comment id serialization to disk.
+- Fix comment ID serialization to disk.
 
 ## 0.5.0
 

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Fix comment id serialization to disk.
+
 ## 0.5.0
 
 - Split health checks in individual workflows.

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -91,7 +91,7 @@ class GithubApi {
   /// Find a comment on the PR matching the given criteria ([user],
   /// [searchTerm]). Return the issue ID if a matching comment is found or null
   /// if there's no match.
-  Future<IssueComment?> findCommentId({
+  Future<int?> findCommentId({
     required String user,
     String? searchTerm,
   }) async {
@@ -107,7 +107,7 @@ class GithubApi {
       },
       orElse: () => null,
     );
-    return matchingComment;
+    return matchingComment?.id;
   }
 
   Future<List<GitFile>> listFilesForPR() async => await github.pullRequests

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/test/github_test.dart
+++ b/pkgs/firehose/test/github_test.dart
@@ -26,14 +26,14 @@ Future<void> main() async {
   });
   test('Find comment', () async {
     var commentId = await github.findCommentId(user: 'auto-submit[bot]');
-    expect(commentId?.id, 1660891263);
+    expect(commentId, 1660891263);
   });
   test('Find comment with searchterm', () async {
     var commentId = await github.findCommentId(
       user: 'auto-submit[bot]',
       searchTerm: 'before re-applying this label.',
     );
-    expect(commentId?.id, 1660891263);
+    expect(commentId, 1660891263);
   });
   test('Find comment with searchterm', () async {
     var commentId = await github.findCommentId(


### PR DESCRIPTION
See the failure here https://github.com/dart-lang/build/actions/runs/7463208455/job/20307339352?pr=3638#step:9:3.

Changes `findCommentId` to again return an `int?` instead of an `IssueComment?`.

Alternatively, we could rename this to `findComment`, and return the entire comment, but we only ever use the ID.

We just call `toString()` on the return value of this function and serialize it to disk, so when it changed to an `IssueComment` it no longer serialized the ID. 