### PR TITLE
Add submodule support to `publish.yaml`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,6 +77,12 @@ on:
         default: true
         required: false
         type: boolean
+      checkout_submodules:
+        description: >-
+          Whether to checkout submodules of git repositories.
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   # Note that this job does not require the specified environment.
@@ -91,10 +97,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         if: ${{ inputs.use-flutter }}
         with:
           channel: ${{ inputs.sdk }}
+          
 
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
         if: ${{ !inputs.use-flutter }}


### PR DESCRIPTION
To fix https://github.com/dart-lang/i18n/actions/runs/7531356775/job/20499753789?pr=740

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
