### PR TITLE
add 'unnecessary_library_name' to package:dart_flutter_team_lints

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,16 +39,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; Dart 3.0.0; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose, pkgs/repo_manage; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 3.0.0; PKGS: pkgs/corpus, pkgs/firehose, pkgs/repo_manage; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose-pkgs/repo_manage;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/corpus-pkgs/firehose-pkgs/repo_manage;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/corpus-pkgs/dart_flutter_team_lints-pkgs/firehose-pkgs/repo_manage
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/corpus-pkgs/firehose-pkgs/repo_manage
             os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -68,15 +68,6 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_corpus_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/corpus
-      - id: pkgs_dart_flutter_team_lints_pub_upgrade
-        name: pkgs/dart_flutter_team_lints; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
-      - name: "pkgs/dart_flutter_team_lints; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
       - id: pkgs_firehose_pub_upgrade
         name: pkgs/firehose; dart pub upgrade
         run: dart pub upgrade
@@ -98,6 +89,38 @@ jobs:
     needs:
       - job_001
   job_003:
+    name: "analyze_and_format; Dart 3.4.0; PKG: pkgs/dart_flutter_team_lints; `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/dart_flutter_team_lints;commands:analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/dart_flutter_team_lints
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - id: pkgs_dart_flutter_team_lints_pub_upgrade
+        name: pkgs/dart_flutter_team_lints; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
+      - name: "pkgs/dart_flutter_team_lints; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
+    needs:
+      - job_001
+  job_004:
     name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose, pkgs/repo_manage; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +179,7 @@ jobs:
         working-directory: pkgs/repo_manage
     needs:
       - job_001
-  job_004:
+  job_005:
     name: "analyze_and_format; Dart dev; PKGS: pkgs/corpus, pkgs/dart_flutter_team_lints, pkgs/firehose, pkgs/repo_manage; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
@@ -215,7 +238,7 @@ jobs:
         working-directory: pkgs/repo_manage
     needs:
       - job_001
-  job_005:
+  job_006:
     name: "unit_test; Dart 3.0.0; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -250,41 +273,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_006:
-    name: "unit_test; Dart 3.0.0; PKG: pkgs/dart_flutter_team_lints; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/dart_flutter_team_lints;commands:test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/dart_flutter_team_lints
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
-        with:
-          sdk: "3.0.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
-      - id: pkgs_dart_flutter_team_lints_pub_upgrade
-        name: pkgs/dart_flutter_team_lints; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
-      - name: pkgs/dart_flutter_team_lints; dart test
-        run: dart test
-        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/dart_flutter_team_lints
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
+      - job_005
   job_007:
     name: "unit_test; Dart 3.0.0; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
@@ -320,7 +309,44 @@ jobs:
       - job_002
       - job_003
       - job_004
+      - job_005
   job_008:
+    name: "unit_test; Dart 3.4.0; PKG: pkgs/dart_flutter_team_lints; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/dart_flutter_team_lints;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/dart_flutter_team_lints
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - id: pkgs_dart_flutter_team_lints_pub_upgrade
+        name: pkgs/dart_flutter_team_lints; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
+      - name: pkgs/dart_flutter_team_lints; dart test
+        run: dart test
+        if: "always() && steps.pkgs_dart_flutter_team_lints_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dart_flutter_team_lints
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_009:
     name: "unit_test; Dart dev; PKG: pkgs/corpus; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -355,7 +381,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_009:
+      - job_005
+  job_010:
     name: "unit_test; Dart dev; PKG: pkgs/dart_flutter_team_lints; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -390,7 +417,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_010:
+      - job_005
+  job_011:
     name: "unit_test; Dart dev; PKG: pkgs/firehose; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -425,7 +453,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
+      - job_005
+  job_012:
     name: "analyze_format; Dart dev; PKG: pkgs/blast_repo; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -470,7 +499,8 @@ jobs:
       - job_008
       - job_009
       - job_010
-  job_012:
+      - job_011
+  job_013:
     name: "test; Dart dev; PKG: pkgs/blast_repo; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -512,3 +542,4 @@ jobs:
       - job_009
       - job_010
       - job_011
+      - job_012

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.0
+# Created with package:mono_repo v6.6.1
 name: Dart CI
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.0
+        run: dart pub global activate mono_repo 6.6.1
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:

--- a/pkgs/blast_repo/pubspec.yaml
+++ b/pkgs/blast_repo/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.22.0
   test_descriptor: ^2.0.0
 

--- a/pkgs/corpus/pubspec.yaml
+++ b/pkgs/corpus/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
 
 dev_dependencies:
   checks: ^0.3.0
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.22.0
   test_descriptor: ^2.0.0

--- a/pkgs/corpus/pubspec_overrides.yaml
+++ b/pkgs/corpus/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  dart_flutter_team_lints:
-    path: ../dart_flutter_team_lints

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.1.2-wip
+## 2.2.0
+
+- Added `unnecessary_library_name`.
 
 ## 2.1.1
 

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.0
 
 - Added `unnecessary_library_name`.
+- Require Dart `3.4`.
 
 ## 2.1.1
 

--- a/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
@@ -35,6 +35,7 @@ linter:
     - sort_pub_dependencies
     - unnecessary_lambdas
     - unnecessary_library_directive
+    - unnecessary_library_name
     - unnecessary_parenthesis
     - unnecessary_statements
     - use_is_even_rather_than_modulo

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.0
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.4.0
 
 dependencies:
   lints: ^3.0.0

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flutter_team_lints
 description: An analysis rule set used by the Dart and Flutter teams.
-version: 2.1.2-wip
+version: 2.2.0
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 
 environment:

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -22,5 +22,5 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.21.0

--- a/pkgs/firehose/pubspec_overrides.yaml
+++ b/pkgs/firehose/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  dart_flutter_team_lints:
-    path: ../dart_flutter_team_lints

--- a/pkgs/repo_manage/pubspec.yaml
+++ b/pkgs/repo_manage/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   path: ^1.8.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^3.0.0

--- a/pkgs/repo_manage/pubspec_overrides.yaml
+++ b/pkgs/repo_manage/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  dart_flutter_team_lints:
-    path: ../dart_flutter_team_lints

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.0
+# Created with package:mono_repo v6.6.1
 
 # Support built in commands on windows out of the box.
+
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
-# then "flutter" is called instead of "pub".
+# then "flutter pub" is called instead of "dart pub".
 # This assumes that the Flutter SDK has been installed in a previous step.
 function pub() {
   if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
@@ -12,18 +13,13 @@ function pub() {
     command dart pub "$@"
   fi
 }
-# When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
-# then "flutter" is called instead of "pub".
-# This assumes that the Flutter SDK has been installed in a previous step.
+
 function format() {
-  if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
-    command flutter format "$@"
-  else
-    command dart format "$@"
-  fi
+  command dart format "$@"
 }
+
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
-# then "flutter" is called instead of "pub".
+# then "flutter analyze" is called instead of "dart analyze".
 # This assumes that the Flutter SDK has been installed in a previous step.
 function analyze() {
   if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then


### PR DESCRIPTION
- add 'unnecessary_library_name' to package:dart_flutter_team_lints
- require dart 3.4 (not yet published as stable)
- regen mono_repo content

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
