### PR TITLE
Update the dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,4 +12,5 @@ updates:
        dependencies:
           patterns: ["*"]
     ignore:
-      update-types: ["version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,6 @@ updates:
       - autosubmit
     groups:
        dependencies:
-          applies-to: version-updates
           patterns: ["*"]
-          update-types: ["major", "minor"]
+    ignore:
+      update-types: ["version-update:semver-patch"]

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,9 +2,14 @@
 version: 2
 
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: monthly
     labels:
-      - "autosubmit"
+      - autosubmit
+    groups:
+       dependencies:
+          applies-to: version-updates
+          patterns: ["*"]
+          update-types: ["major", "minor"]


### PR DESCRIPTION
- experiment with the dependabot config

This config attempts to:
- group all github action updates together
- not try to update to patch versions (except for security updates)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
