### PR TITLE
update dependabot config; update related blast tweak

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,8 +9,6 @@ updates:
     labels:
       - autosubmit
     groups:
-       dependencies:
-          patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+      dependencies:
+        patterns:
+          - "*"

--- a/pkgs/blast_repo/lib/src/tweaks/dependabot_tweak.dart
+++ b/pkgs/blast_repo/lib/src/tweaks/dependabot_tweak.dart
@@ -156,9 +156,16 @@ Iterable<Object> _allowedActionValues() =>
 
 const _packageEcosystemKey = 'package-ecosystem';
 
-Map<String, Object> _githubActionValue(String frequency) => {
-      _packageEcosystemKey: 'github-actions',
-      'directory': '/',
-      'schedule': {'interval': frequency},
-      'labels': ['autosubmit'],
-    };
+Map<String, Object> _githubActionValue(String frequency) {
+  return {
+    _packageEcosystemKey: 'github-actions',
+    'directory': '/',
+    'schedule': {'interval': frequency},
+    'labels': ['autosubmit'],
+    'groups': {
+      'dependencies': {
+        'patterns': ['*']
+      }
+    },
+  };
+}

--- a/pkgs/blast_repo/test/dependabot_test.dart
+++ b/pkgs/blast_repo/test/dependabot_test.dart
@@ -32,7 +32,7 @@ updates: "bob"
     final result = doDependabotFix(r'''
 #some comment
 version: 2
-enable-beta-ecosystems: true
+
 updates:
   - package-ecosystem: "pub"
     directory: "/"
@@ -43,7 +43,7 @@ updates:
     expect(result, r'''
 #some comment
 version: 2
-enable-beta-ecosystems: true
+
 updates:
   - package-ecosystem: "pub"
     directory: "/"
@@ -55,6 +55,10 @@ updates:
       interval: monthly
     labels:
       - autosubmit
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 ''');
   });
 
@@ -74,6 +78,10 @@ updates:
       interval: "$frequency"
     labels:
       - autosubmit
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 ''';
         final result = doDependabotFix(input);
 
@@ -104,4 +112,8 @@ updates:
       interval: monthly
     labels:
       - autosubmit
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 ''';


### PR DESCRIPTION
- update the dependabot config
- update the related blast tweak
- closes https://github.com/dart-lang/ecosystem/issues/260

The previous version of this config would ignore too many (all?) updates. From testing on other repos, this does correctly batch multiple updates into one PR.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
