### PR TITLE
updates for the blast_repo tool

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,6 @@ updates:
     labels:
       - autosubmit
     groups:
-      dependencies:
+      github-actions:
         patterns:
           - "*"

--- a/pkgs/blast_repo/lib/src/tweaks/dependabot_tweak.dart
+++ b/pkgs/blast_repo/lib/src/tweaks/dependabot_tweak.dart
@@ -163,7 +163,7 @@ Map<String, Object> _githubActionValue(String frequency) {
     'schedule': {'interval': frequency},
     'labels': ['autosubmit'],
     'groups': {
-      'dependencies': {
+      'github-actions': {
         'patterns': ['*']
       }
     },

--- a/pkgs/blast_repo/lib/src/utils.dart
+++ b/pkgs/blast_repo/lib/src/utils.dart
@@ -46,6 +46,7 @@ Future<void> runProc(
   String proc,
   List<String> args, {
   required String workingDirectory,
+  bool skipExecution = false,
 }) async {
   printHeader(description);
 
@@ -55,6 +56,12 @@ Future<void> runProc(
       ...args,
     ].join(' '),
   );
+
+  if (skipExecution) {
+    print('** skipping execution for $proc **');
+    return;
+  }
+
   final ghProc = await Process.start(
     proc,
     args,

--- a/pkgs/blast_repo/pubspec.yaml
+++ b/pkgs/blast_repo/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.1.0
 
 dependencies:
-  args: ^2.3.1
+  args: ^2.4.0
   collection: ^1.17.0
   git: ^2.2.0
   github: ^9.6.0

--- a/pkgs/blast_repo/test/dependabot_test.dart
+++ b/pkgs/blast_repo/test/dependabot_test.dart
@@ -56,7 +56,7 @@ updates:
     labels:
       - autosubmit
     groups:
-      dependencies:
+      github-actions:
         patterns:
           - "*"
 ''');
@@ -79,7 +79,7 @@ updates:
     labels:
       - autosubmit
     groups:
-      dependencies:
+      github-actions:
         patterns:
           - "*"
 ''';
@@ -113,7 +113,7 @@ updates:
     labels:
       - autosubmit
     groups:
-      dependencies:
+      github-actions:
         patterns:
           - "*"
 ''';


### PR DESCRIPTION
updates for the blast_repo tool:

- rename the `--keep-temp` flag to `--dry-run`
- group github action dependabot changes into a named `github-actions` group
- optionally specify labels to add to a blast repo PR (like `autosubmit`)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
