### PR TITLE
move to logging; check for safety exceptions

### DIFF
--- a/pkgs/sdk_triage_bot/bin/triage.dart
+++ b/pkgs/sdk_triage_bot/bin/triage.dart
@@ -72,6 +72,7 @@ void main(List<String> arguments) async {
     force: force,
     githubService: githubService,
     geminiService: geminiService,
+    logger: Logger(),
   );
 
   client.close();

--- a/pkgs/sdk_triage_bot/lib/src/common.dart
+++ b/pkgs/sdk_triage_bot/lib/src/common.dart
@@ -41,3 +41,9 @@ String get geminiKey {
 String trimmedBody(String body) {
   return body.length > 4096 ? body = body.substring(0, 4096) : body;
 }
+
+class Logger {
+  void log(String message) {
+    print(message);
+  }
+}

--- a/pkgs/sdk_triage_bot/lib/src/gemini.dart
+++ b/pkgs/sdk_triage_bot/lib/src/gemini.dart
@@ -27,10 +27,16 @@ class GeminiService {
           httpClient: httpClient,
         );
 
+  /// Call the summarize model with the given prompt.
+  ///
+  /// On failures, this will throw a `GenerativeAIException`.
   Future<String> summarize(String prompt) {
     return _query(_summarizeModel, prompt);
   }
 
+  /// Call the classify model with the given prompt.
+  ///
+  /// On failures, this will throw a `GenerativeAIException`.
   Future<List<String>> classify(String prompt) async {
     final result = await _query(_classifyModel, prompt);
     final labels = result.split(',').map((l) => l.trim()).toList();

--- a/pkgs/sdk_triage_bot/test/fakes.dart
+++ b/pkgs/sdk_triage_bot/test/fakes.dart
@@ -3,8 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:github/github.dart';
+import 'package:sdk_triage_bot/src/common.dart';
 import 'package:sdk_triage_bot/src/gemini.dart';
 import 'package:sdk_triage_bot/src/github.dart';
+import 'package:test/test.dart';
 
 const int mockIssueNumber = 123;
 
@@ -53,5 +55,12 @@ class GeminiServiceStub implements GeminiService {
   @override
   Future<List<String>> classify(String prompt) async {
     return ['area-vm', 'type-bug'];
+  }
+}
+
+class TestLogger implements Logger {
+  @override
+  void log(String message) {
+    printOnFailure(message);
   }
 }

--- a/pkgs/sdk_triage_bot/test/triage_test.dart
+++ b/pkgs/sdk_triage_bot/test/triage_test.dart
@@ -17,6 +17,7 @@ void main() {
       mockIssueNumber,
       githubService: githubService,
       geminiService: geminiService,
+      logger: TestLogger(),
     );
 
     expect(githubService.updatedComment, isNotEmpty);
@@ -41,6 +42,7 @@ void main() {
       mockIssueNumber,
       githubService: githubService,
       geminiService: geminiService,
+      logger: TestLogger(),
     );
 
     expect(githubService.updatedComment, isNull);
@@ -61,9 +63,10 @@ void main() {
 
     await triage(
       mockIssueNumber,
+      force: true,
       githubService: githubService,
       geminiService: geminiService,
-      force: true,
+      logger: TestLogger(),
     );
 
     expect(githubService.updatedComment, isNotEmpty);


### PR DESCRIPTION
- in the body of the bot, use a logger instead of `print` statements
- when calling gemini APIs, check for safety issues in the result (`GenerativeAIException` exceptions being thrown)
- update the progress stdout of the bot (for readability, and, to use `issue.htmlUrl` instead of `issue.url` - a human readable url instead of the json api url)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
