### PR TITLE
cosmetic updates to the triage bot's github comment

### DIFF
--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -96,16 +96,17 @@ Future<void> triage(
   // perform changes
   logger.log('## github comment');
   logger.log('');
-  logger.log(summary);
-  logger.log('');
   logger.log('labels: $classification');
+  logger.log('');
+  logger.log(summary);
 
   var comment = '';
   if (classification.isNotEmpty) {
+    comment += '**Labels:** ';
     comment += classification.map((l) => '`$l`').join(', ');
     comment += '\n';
   }
-  comment += '> $summary\n';
+  comment += '**Summary:** $summary\n';
 
   // create github comment
   await githubService.createComment(sdkSlug, issueNumber, comment);


### PR DESCRIPTION
- cosmetic updates to the triage bot's github comment

This changes the comment to look like:

---

**Labels:** `foo`, `bar`

**Summary:** Lorem ipsum.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
