### PR TITLE
improvements for transferred issues

### DIFF
--- a/pkgs/sdk_triage_bot/lib/src/common.dart
+++ b/pkgs/sdk_triage_bot/lib/src/common.dart
@@ -37,9 +37,11 @@ String get geminiKey {
   return token;
 }
 
-/// Don't return more than 4k of text for an issue body.
+/// Don't return more than 5k of text for an issue body.
 String trimmedBody(String body) {
-  return body.length > 4096 ? body = body.substring(0, 4096) : body;
+  const textLimit = 5 * 1024;
+
+  return body.length > textLimit ? body = body.substring(0, textLimit) : body;
 }
 
 class Logger {

--- a/pkgs/sdk_triage_bot/lib/src/github.dart
+++ b/pkgs/sdk_triage_bot/lib/src/github.dart
@@ -19,8 +19,15 @@ class GithubService {
     return result.map((item) => item.name).toList();
   }
 
-  Future<Issue> fetchIssue(RepositorySlug sdkSlug, int issueNumber) async {
-    return await _gitHub.issues.get(sdkSlug, issueNumber);
+  Future<Issue> fetchIssue(RepositorySlug slug, int issueNumber) async {
+    return await _gitHub.issues.get(slug, issueNumber);
+  }
+
+  Future<List<IssueComment>> fetchIssueComments(
+      RepositorySlug slug, Issue issue) async {
+    return await _gitHub.issues
+        .listCommentsByIssue(slug, issue.number)
+        .toList();
   }
 
   Future createComment(
@@ -144,4 +151,11 @@ GraphQLClient _initGraphQLClient() {
     cache: GraphQLCache(),
     link: auth.concat(HttpLink('https://api.github.com/graphql')),
   );
+}
+
+extension IssueExtension on Issue {
+  /// Returns whether this issue has any comments.
+  ///
+  /// Note that the original text for the issue is returned in the `body` field.
+  bool get hasComments => commentsCount > 0;
 }

--- a/pkgs/sdk_triage_bot/lib/src/prompts.dart
+++ b/pkgs/sdk_triage_bot/lib/src/prompts.dart
@@ -5,6 +5,7 @@
 String assignAreaPrompt({
   required String title,
   required String body,
+  String? lastComment,
 }) {
   return '''
 You are a software engineer on the Dart team at Google. You are responsible for
@@ -36,6 +37,7 @@ area-web: Use area-web for Dart web related issues, including the DDC and dart2j
 Don't make up a new area.
 Don't use more than one area- label.
 If it's not clear which area the issue should go in, don't apply an area- label.
+Take your time when considering which area to triage the issue into.
 
 If the issue is clearly a feature request, then also apply the label 'type-enhancement'.
 If the issue is clearly a bug report, then also apply the label 'type-bug'.
@@ -48,7 +50,10 @@ Issue follows:
 
 $title
 
-$body''';
+$body
+
+${lastComment ?? ''}'''
+      .trim();
 }
 
 String summarizeIssuePrompt({

--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -46,6 +46,22 @@ Future<void> triage(
   }
   logger.log('');
 
+  // If the issue has any comments, retrieve and include the last comment in the
+  // prompt.
+  String? lastComment;
+  if (issue.hasComments) {
+    final comments = await githubService.fetchIssueComments(sdkSlug, issue);
+    final comment = comments.last;
+
+    lastComment = '''
+---
+
+Last comment by @${comment.user?.login}:
+
+${trimmedBody(comment.body ?? '')}
+''';
+  }
+
   // decide if we should triage
   final alreadyTriaged = labels.any((l) => l.startsWith('area-'));
   if (alreadyTriaged && !force) {
@@ -76,7 +92,8 @@ Future<void> triage(
   try {
     // Failures here can include things like gemini safety issues, ...
     classification = await geminiService.classify(
-      assignAreaPrompt(title: issue.title, body: bodyTrimmed),
+      assignAreaPrompt(
+          title: issue.title, body: bodyTrimmed, lastComment: lastComment),
     );
   } on GenerativeAIException catch (e) {
     stderr.writeln('gemini: $e');
@@ -121,7 +138,7 @@ Future<void> triage(
   logger.log('');
   logger.log('---');
   logger.log('');
-  logger.log('Triaged ${issue.htmlUrl}.');
+  logger.log('Triaged ${issue.htmlUrl}');
 }
 
 List<String> filterExistingLabels(

--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -56,7 +56,7 @@ Future<void> triage(
     lastComment = '''
 ---
 
-Last comment by @${comment.user?.login}:
+Here is the last comment on the issue (by user @${comment.user?.login}):
 
 ${trimmedBody(comment.body ?? '')}
 ''';

--- a/pkgs/sdk_triage_bot/test/fakes.dart
+++ b/pkgs/sdk_triage_bot/test/fakes.dart
@@ -29,6 +29,12 @@ class GithubServiceMock implements GithubService {
     return returnedIssue;
   }
 
+  @override
+  Future<List<IssueComment>> fetchIssueComments(
+      RepositorySlug slug, Issue issue) {
+    return Future.value([]);
+  }
+
   String? updatedComment;
 
   @override


### PR DESCRIPTION
Improvements for transferred issues:

- if an issue has comments (apart from the initial body), feed the last comment into the prompt; this may help classification for transferred issues, which have presumably already had some discussion
- separate from this PR, delay a bit before triaging an issue: https://dart-review.googlesource.com/c/sdk/+/373020
- add some verbiage around 'take your time...' for the triaging prompt (this _may_ improve the classification results?)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
