### PR TITLE
Remove the use-flutter configuration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,16 +27,6 @@ name: Publish
 #     with:
 #       sdk: beta
 
-# When using this package to publish Flutter packages, the `use-flutter`
-# parameter should be set. The `sdk` parameter is then used to specify
-# the Flutter SDK.
-#
-# jobs:
-#   publish:
-#     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
-#     with:
-#       use-flutter: true
-
 # When using a post_summaries.yaml workflow to post the comments, set
 # the write-comments parameter to false.
 #
@@ -74,12 +64,6 @@ on:
         default: "stable"
         required: false
         type: string
-      use-flutter:
-        description: >-
-          Whether to setup Flutter in this workflow.
-        default: false
-        required: false
-        type: boolean
       write-comments:
         description: >-
           Whether to write a comment in this workflow.
@@ -120,15 +104,8 @@ jobs:
           submodules: ${{ inputs.checkout_submodules }}
 
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1
-        if: ${{ inputs.use-flutter }}
         with:
           channel: ${{ inputs.sdk }}
-          
-
-      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        if: ${{ !inputs.use-flutter }}
-        with:
-          sdk: ${{ inputs.sdk }}
 
       - name: Install firehose
         run: dart pub global activate firehose
@@ -146,7 +123,6 @@ jobs:
         run: |
              dart pub global run firehose \
                --validate \
-               ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }} \
                --ignore-packages ${{ inputs.ignore-packages }}
 
       - name: Get comment id
@@ -203,14 +179,8 @@ jobs:
           submodules: ${{ inputs.checkout_submodules }}
 
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1
-        if: ${{ inputs.use-flutter }}
         with:
           channel: ${{ inputs.sdk }}
-
-      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        if: ${{ !inputs.use-flutter }}
-        with:
-          sdk: ${{ inputs.sdk }}
 
       - name: Install firehose
         run: dart pub global activate firehose

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -198,7 +198,6 @@ jobs:
 | warn_on  | List of strings  | Which checks should not fail, but only warn | `"license,coverage,breaking,leaking"` |
 | upload_coverage  | boolean  | Whether to upload the coverage to [coveralls](https://coveralls.io/) | `true` |
 | coverage_web  | boolean  | Whether to run `dart test -p chrome` for coverage | `false` |
-| use-flutter  | boolean  | Whether to setup Flutter in this workflow | `false` |
 | ignore_license  | List of globs  | | `"**.g.dart"` |
 | ignore_coverage  | List of globs  | Which files to ignore for the license check | `"**.mock.dart,**.g.dart"` |
 | ignore_packages  | List of globs  | Which packages to ignore | `"pkgs/helper_package"` |

--- a/pkgs/firehose/bin/firehose.dart
+++ b/pkgs/firehose/bin/firehose.dart
@@ -11,7 +11,6 @@ import 'package:glob/glob.dart';
 const helpFlag = 'help';
 const validateFlag = 'validate';
 const publishFlag = 'publish';
-const useFlutterFlag = 'use-flutter';
 
 void main(List<String> arguments) async {
   var argParser = _createArgs();
@@ -25,7 +24,6 @@ void main(List<String> arguments) async {
 
     final validate = argResults[validateFlag] as bool;
     final publish = argResults[publishFlag] as bool;
-    final useFlutter = argResults[useFlutterFlag] as bool;
     final ignoredPackages = (argResults['ignore-packages'] as List<String>)
         .where((pattern) => pattern.isNotEmpty)
         .map((pattern) => Glob(pattern, recursive: true))
@@ -45,7 +43,7 @@ void main(List<String> arguments) async {
       exit(1);
     }
 
-    final firehose = Firehose(Directory.current, useFlutter, ignoredPackages);
+    final firehose = Firehose(Directory.current, ignoredPackages);
 
     if (validate) {
       await firehose.validate();
@@ -87,11 +85,6 @@ ArgParser _createArgs() {
       publishFlag,
       negatable: false,
       help: 'Publish any changed packages.',
-    )
-    ..addFlag(
-      useFlutterFlag,
-      negatable: true,
-      help: 'Whether this is a Flutter project.',
     )
     ..addMultiOption(
       'ignore-packages',

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -29,10 +29,9 @@ const String _ignoreWarningsLabel = 'publish-ignore-warnings';
 
 class Firehose {
   final Directory directory;
-  final bool useFlutter;
   final List<Glob> ignoredPackages;
 
-  Firehose(this.directory, this.useFlutter, this.ignoredPackages);
+  Firehose(this.directory, this.ignoredPackages);
 
   /// Validate the packages in the repository.
   ///
@@ -273,14 +272,8 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     required bool dryRun,
     required bool force,
   }) async {
-    String command;
-    if (useFlutter) {
-      command = 'flutter';
-    } else {
-      command = 'dart';
-    }
     return await runCommand(
-      command,
+      'flutter',
       args: [
         'pub',
         'publish',


### PR DESCRIPTION
Always set up the flutter SDK and use `flutter pub publish`, even for
non-flutter Dart packages. The `flutter` command can publish non-flutter
packages so no behavior changes are expected during the publish action.

Directly remove the argument, configuration, and all references
immediately. There is no plan for a deprecation/migration phase since
this only impacts CI, and the fix is trivial.
