### PR TITLE
Add check label to github action job name

### DIFF
--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -77,7 +77,7 @@ on:
 
 jobs:
   health:
-    name: run
+    name: run ${{ inputs.check }} health check
     # These permissions are required for us to create comments on PRs.
     permissions:
       pull-requests: write


### PR DESCRIPTION
Without this change the tree of jobs shows "health" with a series of 7
"run" jobs nested underneath.
Add the check name from the input to the job name.
