### PR TITLE
fix calculation for the labels to apply

### DIFF
--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -124,7 +124,7 @@ ${trimmedBody(comment.body ?? '')}
   await githubService.createComment(sdkSlug, issueNumber, comment);
 
   final allRepoLabels = (await githubService.getAllLabels(sdkSlug)).toSet();
-  final labelAdditions = newLabels.toSet().union(allRepoLabels).toList()
+  final labelAdditions = newLabels.toSet().intersection(allRepoLabels).toList()
     ..sort();
   if (labelAdditions.isNotEmpty) {
     labelAdditions.add('triage-automation');


### PR DESCRIPTION
- fix calculation for the labels to apply

https://github.com/dart-lang/ecosystem/pull/292 had inadvertently changed the logic to `union`, which was trying to apply all existing labels to new issues.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
