### PR TITLE
update the prompt to include `needs-info`

### DIFF
--- a/pkgs/sdk_triage_bot/lib/src/common.dart
+++ b/pkgs/sdk_triage_bot/lib/src/common.dart
@@ -37,9 +37,9 @@ String get geminiKey {
   return token;
 }
 
-/// Don't return more than 5k of text for an issue body.
+/// Don't return more than 10k of text for an issue body.
 String trimmedBody(String body) {
-  const textLimit = 5 * 1024;
+  const textLimit = 10 * 1024;
 
   return body.length > textLimit ? body = body.substring(0, textLimit) : body;
 }

--- a/pkgs/sdk_triage_bot/lib/src/common.dart
+++ b/pkgs/sdk_triage_bot/lib/src/common.dart
@@ -37,11 +37,14 @@ String get geminiKey {
   return token;
 }
 
-/// Don't return more than 10k of text for an issue body.
-String trimmedBody(String body) {
-  const textLimit = 10 * 1024;
+/// Maximal length of body used for querying.
+const bodyLengthLimit = 10 * 1024;
 
-  return body.length > textLimit ? body = body.substring(0, textLimit) : body;
+/// The [body], truncated if larger than [bodyLengthLimit].
+String trimmedBody(String body) {
+  return body.length > bodyLengthLimit
+      ? body = body.substring(0, bodyLengthLimit)
+      : body;
 }
 
 class Logger {

--- a/pkgs/sdk_triage_bot/lib/src/gemini.dart
+++ b/pkgs/sdk_triage_bot/lib/src/gemini.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 
 class GeminiService {
   // gemini-1.5-pro-latest, gemini-1.5-flash-latest, gemini-1.0-pro-latest
+  // gemini-1.5-flash-exp-0827
   static const String classificationModel = 'models/gemini-1.5-flash-latest';
   static const String summarizationModel = 'models/gemini-1.5-flash-latest';
 

--- a/pkgs/sdk_triage_bot/lib/src/gemini.dart
+++ b/pkgs/sdk_triage_bot/lib/src/gemini.dart
@@ -44,7 +44,7 @@ class GeminiService {
   /// On failures, this will throw a `GenerativeAIException`.
   Future<List<String>> classify(String prompt) async {
     final result = await _query(_classifyModel, prompt);
-    final labels = result.split(',').map((l) => l.trim()).toList();
+    final labels = result.split(',').map((l) => l.trim()).toList()..sort();
     return labels;
   }
 

--- a/pkgs/sdk_triage_bot/lib/src/gemini.dart
+++ b/pkgs/sdk_triage_bot/lib/src/gemini.dart
@@ -6,8 +6,8 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:http/http.dart' as http;
 
 class GeminiService {
-  // gemini-1.5-pro-latest, gemini-1.5-flash-latest, gemini-1.0-pro-latest
-  // gemini-1.5-flash-exp-0827
+  // Possible values for models: gemini-1.5-pro-latest, gemini-1.5-flash-latest,
+  // gemini-1.0-pro-latest, gemini-1.5-flash-exp-0827.
   static const String classificationModel = 'models/gemini-1.5-flash-latest';
   static const String summarizationModel = 'models/gemini-1.5-flash-latest';
 
@@ -34,14 +34,14 @@ class GeminiService {
 
   /// Call the summarize model with the given prompt.
   ///
-  /// On failures, this will throw a `GenerativeAIException`.
+  /// On failures, this will throw a [GenerativeAIException].
   Future<String> summarize(String prompt) {
     return _query(_summarizeModel, prompt);
   }
 
   /// Call the classify model with the given prompt.
   ///
-  /// On failures, this will throw a `GenerativeAIException`.
+  /// On failures, this will throw a [GenerativeAIException].
   Future<List<String>> classify(String prompt) async {
     final result = await _query(_classifyModel, prompt);
     final labels = result.split(',').map((l) => l.trim()).toList()..sort();

--- a/pkgs/sdk_triage_bot/lib/src/prompts.dart
+++ b/pkgs/sdk_triage_bot/lib/src/prompts.dart
@@ -45,13 +45,55 @@ If the issue is clearly a bug report, then also apply the label 'type-bug'.
 If the issue is mostly a question,  then also apply the label 'type-question'.
 Otherwise don't apply a 'type-' label.
 
+If the issue was largely unchanged from our default issue template, then apply the
+'needs-info' label and don't assign an area label. These issues will generally
+have a title of "Create an issue" and the body will start with
+"Thank you for taking the time to file an issue!".
+
+If the issue title is "Analyzer Feedback from IntelliJ", these are generally not
+well qualified. For these issues, apply the 'needs-info' label but don't assign
+an area label.
+
+If the issue title starts with "[breaking change] " then it doesn't need to be
+triaged into a specific area; apply the `breaking-change-request` label but
+don't assign an area label.
+
 Return the labels as comma separated text.
 
-Issue follows:
+Here are a series of few-shot examples:
 
-$title
+<EXAMPLE>
+INPUT: title: Create an issue
 
-$body
+body: Thank you for taking the time to file an issue!
+
+This tracker is for issues related to:
+
+Dart analyzer and linter
+Dart core libraries (dart:async, dart:io, etc.)
+Dart native and web compilers
+Dart VM
+
+OUTPUT: needs-info
+</EXAMPLE>
+
+<EXAMPLE>
+INPUT: title: Analyzer Feedback from IntelliJ
+
+body: ## Version information
+
+- `IDEA AI-202.7660.26.42.7351085`
+- `3.4.4`
+- `AI-202.7660.26.42.7351085, JRE 11.0.8+10-b944.6842174x64 JetBrains s.r.o, OS Windows 10(amd64) v10.0 , screens 1600x900`
+
+OUTPUT: needs-info
+</EXAMPLE>
+
+The issue to triage follows:
+
+title: $title
+
+body: $body
 
 ${lastComment ?? ''}'''
       .trim();
@@ -60,15 +102,28 @@ ${lastComment ?? ''}'''
 String summarizeIssuePrompt({
   required String title,
   required String body,
+  required bool needsInfo,
 }) {
+  const needsMoreInfo = '''
+Our classification model determined that we'll need more information to triage
+this issue. Please gently prompt the user to provide more information.
+''';
+
+  final needsInfoVerbiage = needsInfo ? needsMoreInfo : '';
+  final responseLimit = needsInfo
+      ? '2-3 sentences, 50 words or less'
+      : '1-2 sentences, 24 words or less';
+
   return '''
 You are a software engineer on the Dart team at Google. You are responsible for
 triaging incoming issues from users. For each issue, briefly summarize the issue
-(1-2 sentences, 24 words or less).
+($responseLimit).
 
-Issue follows:
+$needsInfoVerbiage
 
-$title
+The issue to triage follows:
 
-$body''';
+title: $title
+
+body: $body''';
 }

--- a/pkgs/sdk_triage_bot/lib/src/prompts.dart
+++ b/pkgs/sdk_triage_bot/lib/src/prompts.dart
@@ -47,14 +47,14 @@ If the issue is clearly a bug report, then also apply the label 'type-bug'.
 If the issue is mostly a question,  then also apply the label 'type-question'.
 Otherwise don't apply a 'type-' label.
 
-If the issue title starts with "[breaking change]" then apply the
-`breaking-change-request` label but don't assign an area label. IMPORTANT: only
-do this if the issue title starts with "[breaking change]".
+If the issue title starts with "[breaking change]" it was likely created using
+existing issue template; do not assign an area label. IMPORTANT: only do this if
+the issue title starts with "[breaking change]".
 
-If the issue was largely unchanged from our default issue template, then apply the
-'needs-info' label and don't assign an area label. These issues will generally
-have a title of "Create an issue" and the body will start with
-"Thank you for taking the time to file an issue!".
+If the issue was largely unchanged from our default issue template, then apply
+the 'needs-info' label and don't assign an area label. These issues will
+generally have a title of "Create an issue" and the body will start with "Thank
+you for taking the time to file an issue!".
 
 If the issue title is "Analyzer Feedback from IntelliJ", these are generally not
 well qualified. For these issues, apply the 'needs-info' label but don't assign

--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -131,9 +131,9 @@ ${trimmedBody(comment.body ?? '')}
   // create github comment
   await githubService.createComment(sdkSlug, issueNumber, comment);
 
-  final allRepoLabels = (await githubService.getAllLabels(sdkSlug)).toSet();
-  final labelAdditions = newLabels.toSet().intersection(allRepoLabels).toList()
-    ..sort();
+  final allRepoLabels = await githubService.getAllLabels(sdkSlug);
+  final labelAdditions =
+      filterLegalLabels(newLabels, allRepoLabels: allRepoLabels);
   if (labelAdditions.isNotEmpty) {
     labelAdditions.add('triage-automation');
   }
@@ -149,7 +149,9 @@ ${trimmedBody(comment.body ?? '')}
   logger.log('Triaged ${issue.htmlUrl}');
 }
 
-List<String> filterExistingLabels(
-    List<String> allLabels, List<String> newLabels) {
-  return newLabels.toSet().intersection(allLabels.toSet()).toList();
+List<String> filterLegalLabels(
+  List<String> labels, {
+  required List<String> allRepoLabels,
+}) {
+  return labels.toSet().intersection(allRepoLabels.toSet()).toList()..sort();
 }

--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -153,5 +153,9 @@ List<String> filterLegalLabels(
   List<String> labels, {
   required List<String> allRepoLabels,
 }) {
-  return labels.toSet().intersection(allRepoLabels.toSet()).toList()..sort();
+  final validLabels = allRepoLabels.toSet();
+  return [
+    for (var label in labels)
+      if (validLabels.contains(label)) label,
+  ]..sort();
 }

--- a/pkgs/sdk_triage_bot/todo.txt
+++ b/pkgs/sdk_triage_bot/todo.txt
@@ -1,0 +1,2 @@
+
+- special case `area-pkg`

--- a/pkgs/sdk_triage_bot/todo.txt
+++ b/pkgs/sdk_triage_bot/todo.txt
@@ -1,2 +1,0 @@
-
-- special case `area-pkg`

--- a/pkgs/sdk_triage_bot/tool/bench.dart
+++ b/pkgs/sdk_triage_bot/tool/bench.dart
@@ -109,12 +109,12 @@ class ClassificationResults {
   }
 
   bool satisfiedBy(List<String> labels) {
-    // handle needs-info
+    // Handle a `needs-info` label.
     if (expectedLabels.contains('needs-info')) {
       return labels.contains('needs-info');
     }
 
-    // handle breaking-change-request
+    // Handle a `breaking-change-request` label.
     if (expectedLabels.contains('breaking-change-request')) {
       return labels.contains('breaking-change-request');
     }

--- a/pkgs/sdk_triage_bot/tool/bench.md
+++ b/pkgs/sdk_triage_bot/tool/bench.md
@@ -20,7 +20,6 @@ materially improve the classification performance.
 | #56354 | `area-web`, `type-bug`                          |
 | #56353 | `area-dart2wasm`                                |
 | #56350 | `area-analyzer`, `type-enhancement`             |
-| #56348 | `area-intellij`                                 |
 | #56347 | `area-dart-cli`, `type-bug`                     |
 | #56346 | `area-pkg`, `pkg-json`, `type-enhancement`      |
 | #56345 | `area-analyzer`, `type-enhancement`             |
@@ -44,7 +43,7 @@ materially improve the classification performance.
 | #56316 | `area-web`                                      |
 | #56315 | `area-web`                                      |
 | #56314 | `area-web`, `type-bug`                          |
-| #56308 | `area-vm`                                       |
+| #56308 | `area-vm` `breaking-change-request`             |
 | #56306 | `area-vm`, `type-bug`                           |
 | #56305 | `area-front-end`, `type-bug`, `type-question`   |
 | #56304 | `area-core-library`, `type-enhancement`         |
@@ -55,13 +54,12 @@ materially improve the classification performance.
 | #56283 | `area-dart2wasm`                                |
 | #56256 | `area-front-end`, `type-bug`                    |
 | #56254 | `area-pkg`, `pkg-vm-service`, `type-bug`        |
-| #56246 | `area-intellij`                                 |
-| #56240 | `area-intellij`                                 |
+| #56240 | `needs-info`                                    |
 | #56229 | `area-infrastructure`                           |
 | #56227 | `area-native-interop`                           |
 | #56220 | `area-infrastructure`, `type-code-health`       |
 | #56217 | `area-meta`                                     |
-| #56216 | `area-intellij`                                 |
+| #56216 | `needs-info`                                    |
 | #56214 | `area-native-interop`                           |
 | #56208 | `area-google3`, `type-enhancement`              |
 | #56207 | `area-google3`                                  |
@@ -108,3 +106,4 @@ We need more information from the user before we can triage these issues.
 
 ## Results
 2024-08-27: 55.6% using gemini-1.5-flash-latest
+2024-08-30: 64.8% using gemini-1.5-flash-latest


### PR DESCRIPTION
- update the prompt to include triaging issues w/ `needs-info` labels
- `[breaking change]` issues should have `breaking-change-request` labels but don't necessarily need area labels
- add 5 'few-shot' examples in the classification prompt
- update benchmark expectations
- classification performance has generally improved from 56% to 65%

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
