### PR TITLE
update the trebuchet remaining steps output into a markdown list

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,3 +27,7 @@
 'package:sdk_triage_bot':
   - changed-files:
       - any-glob-to-any-file: 'pkgs/sdk_triage_bot/**/*'
+
+'package:trebuchet':
+  - changed-files:
+      - any-glob-to-any-file: 'pkgs/trebuchet/**/*'

--- a/pkgs/trebuchet/README.md
+++ b/pkgs/trebuchet/README.md
@@ -9,10 +9,11 @@ dart run bin/trebuchet.dart \
   --input-name coverage \
   --branch-name main \
   --input-path ~/projects/coverage/ \
-  --target labs \
+  --target tools \
   --target-path ~/projects/tools/ \
   --git-filter-repo ~/tools/git-filter-repo \
   --dry-run
 ```
 
-This basically executes the instructions at https://github.com/dart-lang/ecosystem/wiki/Merging-existing-repos-into-a-monorepo
+This script automates portions of the instructions at
+https://github.com/dart-lang/ecosystem/wiki/Merging-existing-repos-into-a-monorepo.

--- a/pkgs/trebuchet/bin/trebuchet.dart
+++ b/pkgs/trebuchet/bin/trebuchet.dart
@@ -165,23 +165,23 @@ class Trebuchet {
     }
 
     final remainingSteps = [
-      'Move and fix workflow files',
+      'move and fix workflow files',
       if (!shouldPush)
-        'Run `git push --set-upstream origin merge-$input-package` in the monorepo directory',
-      'Disable squash-only in GitHub settings, and merge with a fast forward merge to the main branch, enable squash-only in GitHub settings.',
-      "Push tags to github using `git tag --list '$input*' | xargs git push origin`",
-      'Follow up with a PR adding links to the top-level readme table.',
-      'Transfer issues by running `dart run pkgs/repo_manage/bin/report.dart transfer-issues --source-repo dart-lang/$input --target-repo dart-lang/$target --add-label package:$input --apply-changes`',
-      "Add a commit to https://github.com/dart-lang/$input/ with it's readme pointing to the monorepo.",
-      'Update the auto-publishing settings on pub.dev/packages/$input.',
-      'Archive https://github.com/dart-lang/$input/.',
+        'run `git push --set-upstream origin merge-$input-package` in the monorepo directory',
+      "enable 'Allow merge commits' in GitHub settings; merge the PR with 'Create a merge commit'; disable 'Allow merge commits'",
+      "push tags to GitHub using `git tag --list '$input*' | xargs git push origin`",
+      'follow up with a PR adding links to the top-level readme table',
+      'transfer issues by running `dart run pkgs/repo_manage/bin/report.dart transfer-issues --source-repo dart-lang/$input --target-repo dart-lang/$target --add-label package:$input --apply-changes`',
+      'update the auto-publishing settings on pub.dev/packages/$input',
+      "add a commit to https://github.com/dart-lang/$input/ with it's readme pointing to the monorepo",
+      'archive https://github.com/dart-lang/$input/',
     ];
 
     print('DONE!');
     print('''
 Steps left to do:
 
-${remainingSteps.map((step) => '  - $step').join('\n')}
+${remainingSteps.map((step) => '- [ ] $step').join('\n')}
 ''');
   }
 


### PR DESCRIPTION
- update the trebuchet remaining steps output into a markdown list; this could then be added to a PR in order to track the remaining transfer work

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
