### PR TITLE
ignore redundant 'type-' labels

### DIFF
--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -29,9 +29,9 @@ Future<void> triage(
   final issue = await githubService.fetchIssue(sdkSlug, issueNumber);
   logger.log('## issue ${issue.htmlUrl}');
   logger.log('');
-  final labels = issue.labels.map((l) => l.name).toList();
-  if (labels.isNotEmpty) {
-    logger.log('labels: ${labels.join(', ')}');
+  final existingLabels = issue.labels.map((l) => l.name).toList();
+  if (existingLabels.isNotEmpty) {
+    logger.log('labels: ${existingLabels.join(', ')}');
     logger.log('');
   }
   logger.log('"${issue.title}"');
@@ -86,6 +86,11 @@ ${trimmedBody(comment.body ?? '')}
     // Failures here can include things like gemini safety issues, ...
     stderr.writeln('gemini: $e');
     exit(1);
+  }
+
+  // If an issue already has a `type-` label, we don't need to apply more.
+  if (existingLabels.any((label) => label.startsWith('type-'))) {
+    newLabels.removeWhere((label) => label.startsWith('type-'));
   }
 
   // ask for the summary

--- a/pkgs/sdk_triage_bot/test/triage_test.dart
+++ b/pkgs/sdk_triage_bot/test/triage_test.dart
@@ -74,4 +74,26 @@ void main() {
     expect(githubService.updatedLabels, contains(startsWith('area-')));
     expect(githubService.updatedLabels, contains('triage-automation'));
   });
+
+  test('ignore redundant type labels', () async {
+    final githubService = GithubServiceMock();
+    final geminiService = GeminiServiceStub();
+
+    githubService.returnedIssue = Issue(
+      url: 'https://github.com/dart-lang/sdk/issues/55869',
+      title: 'Add full support for service ID zones',
+      number: mockIssueNumber,
+      body: 'Lorem ipsum.',
+      labels: [IssueLabel(name: 'type-enhancement')],
+    );
+
+    await triage(
+      mockIssueNumber,
+      githubService: githubService,
+      geminiService: geminiService,
+      logger: TestLogger(),
+    );
+
+    expect(githubService.updatedLabels, ['area-vm', 'triage-automation']);
+  });
 }


### PR DESCRIPTION
sdk triage bot updates:
- if an issue already has a `type-` label, don't add any as part of the triage process
- address feedback from https://github.com/dart-lang/ecosystem/issues/271#issuecomment-2429507938

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
