### PR TITLE
add a roadmap to our various mono-repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Dart CI](https://github.com/dart-lang/ecosystem/actions/workflows/dart.yml/badge.svg)](https://github.com/dart-lang/ecosystem/actions/workflows/dart.yml)
-
 ## Overview
 
 This repository is home to general Dart Ecosystem tools and packages.
@@ -15,6 +13,33 @@ This repository is home to general Dart Ecosystem tools and packages.
 | [repo_manage](pkgs/repo_manage/) | Miscellaneous issue, repo, and PR query tools. |  |
 | [sdk_triage_bot](pkgs/sdk_triage_bot/) | A triage automation tool for dart-lang/sdk issues. |  |
 | [trebuchet](pkgs/trebuchet/) | A tool for moving existing packages into monorepos. |  |
+
+## Dart mono-repos
+
+The Dart team generally organizes its code into mono-repos; here's a roadmap.
+
+| Main repo | Description |
+| --- | --- |
+| [sdk](https://github.com/dart-lang/sdk) | The Dart SDK, including the VM, JS and Wasm compilers, analysis, core libraries, and more. |
+
+| SLO mono-repos | Description |
+| --- | --- |
+| [core](https://github.com/dart-lang/core) | This repository is home to core Dart packages. |
+| [tools](https://github.com/dart-lang/tools) | This repository is home to tooling related Dart packages. |
+| [labs](https://github.com/dart-lang/labs) | This repository is home to Dart 'labs' packages. |
+
+| Topic mono-repos | Description |
+| --- | --- |
+| [build](https://github.com/dart-lang/build) | A build system for Dart written in Dart |
+| [ecosystem](https://github.com/dart-lang/ecosystem) | This repository is home to general Dart Ecosystem tools and packages. |
+| [http](https://github.com/dart-lang/http) | A composable API for making HTTP requests in Dart. |
+| [i18n](https://github.com/dart-lang/i18n) | A general mono-repo for Dart i18n and l10n packages. |
+| [leak_tracker](https://github.com/dart-lang/leak_tracker) | A framework for memory leak tracking for Dart and Flutter applications. |
+| [macros](https://github.com/dart-lang/macros) | A Dart mono-repo for macro development. |
+| [native](https://github.com/dart-lang/native) | Dart packages related to FFI and native assets bundling. |
+| [shelf](https://github.com/dart-lang/shelf) | Web server middleware for Dart |
+| [test](https://github.com/dart-lang/test) | A library for writing unit tests in Dart. |
+| [webdev](https://github.com/dart-lang/webdev) | A CLI for Dart web development. |
 
 ## Publishing automation
 


### PR DESCRIPTION
- add a roadmap to our various mono-repos

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
