### PR TITLE
address a `Bad state: No element` element exception

### DIFF
--- a/pkgs/sdk_triage_bot/lib/triage.dart
+++ b/pkgs/sdk_triage_bot/lib/triage.dart
@@ -51,15 +51,16 @@ Future<void> triage(
   String? lastComment;
   if (issue.hasComments) {
     final comments = await githubService.fetchIssueComments(sdkSlug, issue);
-    final comment = comments.last;
-
-    lastComment = '''
+    final comment = comments.lastOrNull;
+    if (comment != null) {
+      lastComment = '''
 ---
 
 Here is the last comment on the issue (by user @${comment.user?.login}):
 
 ${trimmedBody(comment.body ?? '')}
 ''';
+    }
   }
 
   // decide if we should triage


### PR DESCRIPTION
- address a `Bad state: No element` element exception

It looks like even when the issue reports that it has comments, retrieving the list of comments for an issue can return an empty list.

```
Unhandled exception:
Bad state: No element
#0      List.last (dart:core-patch/growable_array.dart:349:5)
#1      triage (package:sdk_triage_bot/triage.dart:54:30)
<asynchronous suspension>
#2      main (file:///home/runner/work/sdk/sdk/pkgs/sdk_triage_bot/bin/triage.dart:69:3)
<asynchronous suspension>
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
