### PR TITLE
Don't check licenses of generated files

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2-wip
+
+- Don't check licenses of generated files in PR health workflow.
+
 ## 0.10.1
 
 - Small fixes to the PR health checker.

--- a/pkgs/firehose/lib/src/health/coverage.dart
+++ b/pkgs/firehose/lib/src/health/coverage.dart
@@ -41,11 +41,13 @@ class Coverage {
         .where((file) => file.status != FileStatus.removed)
         .where((file) => isInSomePackage(packages, file.filename))
         .where((file) => isNotATest(packages, file.filename))
+        .whereNot(
+            (file) => ignoredFiles.any((glob) => glob.matches(file.filename)))
         .toList();
     print('The files of interest are $filesOfInterest');
 
     var baseRepository = Repository(base);
-    var basePackages = baseRepository.locatePackages(ignore: ignoredFiles);
+    var basePackages = baseRepository.locatePackages(ignore: ignoredPackages);
     print('Found packages $basePackages at $base');
 
     var changedPackages = packages

--- a/pkgs/firehose/lib/src/health/coverage.dart
+++ b/pkgs/firehose/lib/src/health/coverage.dart
@@ -41,8 +41,8 @@ class Coverage {
         .where((file) => file.status != FileStatus.removed)
         .where((file) => isInSomePackage(packages, file.filename))
         .where((file) => isNotATest(packages, file.filename))
-        .whereNot(
-            (file) => ignoredFiles.any((glob) => glob.matches(file.filename)))
+        .where(
+            (file) => ignoredFiles.none((glob) => glob.matches(file.filename)))
         .toList();
     print('The files of interest are $filesOfInterest');
 

--- a/pkgs/firehose/lib/src/health/license.dart
+++ b/pkgs/firehose/lib/src/health/license.dart
@@ -26,8 +26,8 @@ Future<List<String>> getFilesWithoutLicenses(
         if (ignoredFiles.none((glob) =>
             glob.matches(path.relative(file.path, from: repositoryDir.path)))) {
           var fileContents = File(file.path).readAsStringSync();
-          var fileContainsCopyright = fileContents.contains('// Copyright (c)');
-          if (!fileContainsCopyright) {
+          if (!fileIsGenerated(fileContents) &&
+              !fileContainsCopyright(fileContents)) {
             print(relativePath);
             return relativePath;
           }
@@ -40,3 +40,11 @@ Future<List<String>> getFilesWithoutLicenses(
 Done, found ${filesWithoutLicenses.length} files without license headers''');
   return filesWithoutLicenses;
 }
+
+bool fileIsGenerated(String fileContents) => fileContents
+    .split('\n')
+    .takeWhile((line) => line.startsWith('//') || line.isEmpty)
+    .any((line) => line.toLowerCase().contains('generate'));
+
+bool fileContainsCopyright(String fileContents) =>
+    fileContents.contains('// Copyright (c)');

--- a/pkgs/firehose/lib/src/health/license.dart
+++ b/pkgs/firehose/lib/src/health/license.dart
@@ -26,7 +26,7 @@ Future<List<String>> getFilesWithoutLicenses(
         if (ignoredFiles.none((glob) =>
             glob.matches(path.relative(file.path, from: repositoryDir.path)))) {
           var fileContents = File(file.path).readAsStringSync();
-          if (!fileIsGenerated(fileContents) &&
+          if (!fileIsGenerated(fileContents, file.path) &&
               !fileContainsCopyright(fileContents)) {
             print(relativePath);
             return relativePath;
@@ -41,10 +41,12 @@ Done, found ${filesWithoutLicenses.length} files without license headers''');
   return filesWithoutLicenses;
 }
 
-bool fileIsGenerated(String fileContents) => fileContents
-    .split('\n')
-    .takeWhile((line) => line.startsWith('//') || line.isEmpty)
-    .any((line) => line.toLowerCase().contains('generate'));
+bool fileIsGenerated(String fileContents, String path) =>
+    path.endsWith('g.dart') ||
+    fileContents
+        .split('\n')
+        .takeWhile((line) => line.startsWith('//') || line.isEmpty)
+        .any((line) => line.toLowerCase().contains('generate'));
 
 bool fileContainsCopyright(String fileContents) =>
     fileContents.contains('// Copyright (c)');

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.10.1
+version: 0.10.2-wip
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:

--- a/pkgs/firehose/test_data/golden/comment_license.md
+++ b/pkgs/firehose/test_data/golden/comment_license.md
@@ -12,7 +12,6 @@
 | Files |
 | :--- |
 |pkgs/package1/bin/package1.dart|
-|pkgs/package2/lib/anotherLib.dart|
 |pkgs/package5/lib/src/package5_base.dart|
 
 All source files should start with a [license header](https://github.com/dart-lang/ecosystem/wiki/License-Header).

--- a/pkgs/firehose/test_data/golden/comment_license_healthchanged.md
+++ b/pkgs/firehose/test_data/golden/comment_license_healthchanged.md
@@ -14,7 +14,6 @@
 |pkgs/package1/bin/package1.dart|
 |pkgs/package1/lib/package1.dart|
 |pkgs/package1/test/package1_test.dart|
-|pkgs/package2/lib/anotherLib.dart|
 |pkgs/package2/lib/package2.dart|
 |pkgs/package2/test/package2_test.dart|
 |pkgs/package3/bin/package3.dart|

--- a/pkgs/firehose/test_data/golden/comment_license_ignore_license.md
+++ b/pkgs/firehose/test_data/golden/comment_license_ignore_license.md
@@ -12,7 +12,6 @@
 | Files |
 | :--- |
 |pkgs/package1/bin/package1.dart|
-|pkgs/package2/lib/anotherLib.dart|
 |pkgs/package5/lib/src/package5_base.dart|
 
 All source files should start with a [license header](https://github.com/dart-lang/ecosystem/wiki/License-Header).

--- a/pkgs/firehose/test_data/golden/comment_license_ignore_package.md
+++ b/pkgs/firehose/test_data/golden/comment_license_ignore_package.md
@@ -11,7 +11,6 @@
 
 | Files |
 | :--- |
-|pkgs/package2/lib/anotherLib.dart|
 |pkgs/package5/lib/src/package5_base.dart|
 
 All source files should start with a [license header](https://github.com/dart-lang/ecosystem/wiki/License-Header).

--- a/pkgs/firehose/test_data/test_repo/pkgs/package2/lib/anotherLib.dart
+++ b/pkgs/firehose/test_data/test_repo/pkgs/package2/lib/anotherLib.dart
@@ -1,3 +1,6 @@
+// SOME COMMENT
+// THIS IS A GENERATED FILE
+
 int calculateUnused() {
   return 6 * 7;
 }


### PR DESCRIPTION
To avoid having to exclude many files, don't check the licenses of auto generated files. These are recognized by the word `generate` appearing somewhere in the leading comment lines.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
