### PR TITLE
[dart_flutter_team_lints] add strict_top_level_inference

### DIFF
--- a/.github/workflows/dart_flutter_team_lints.yml
+++ b/.github/workflows/dart_flutter_team_lints.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable, dev]
+        sdk: [dev] # TODO: add back in stable
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94

--- a/.github/workflows/health_internal.yaml
+++ b/.github/workflows/health_internal.yaml
@@ -1,14 +1,17 @@
 # A CI configuration to check PR health.
 
 name: Health:Internal
+
 on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
+
 jobs:
   health:
     uses: ./.github/workflows/health.yaml
     with:
+      sdk: dev
       local_debug: true
       coverage_web: false
       upload_coverage: false

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -4,12 +4,14 @@
 # publishing code at head.
 
 name: Publish:Internal
+
 on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+
 jobs:
   publish:
     uses: ./.github/workflows/publish.yaml
@@ -17,3 +19,4 @@ jobs:
       local_debug: true
       use-flutter: false
       write-comments: false
+      sdk: dev

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.3.0
+
+- Added `strict_top_level_inference`.
+- Require Dart `3.7`.
+
 ## 3.2.1
 
 - Depend on the `5.0.0` release of `package:lints`.

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.3.0
+## 3.3.0
 
 - Added `strict_top_level_inference`.
 - Require Dart `3.7`.

--- a/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
@@ -45,6 +45,7 @@ linter:
     - comment_references
     - conditional_uri_does_not_exist
     - only_throw_errors
+    - strict_top_level_inference
     - test_types_in_equals
     - throw_in_finally
     - type_annotate_public_apis

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dart_flutter_team_lints
 description: An analysis rule set used by the Dart and Flutter teams.
-version: 3.2.1
+version: 3.3.0
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.7.0-0
 
 dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
- add the new `strict_top_level_inference` lint
- update the sdk dependency
- rev for publishing

Note that this won't build cleanly until a dev sdk is released that contains `strict_top_level_inference`; I'll hold off on landing / publishing this until then.

w/ the pubspec constraints here:
- most packages using this (^3.0.0) will solve for this new version of the package
- they'll only get this version if they happen to be running `pub get` on a 3.7 dev version of the sdk
- many repos in dart-lang will pick up this version, but only from the build jobs running on a dev sdk

I think we can publish this and fix up the failing jobs reactively.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
