### PR TITLE
print detailed info about the leaked APIs to stdout in the workflow

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.10.2-wip
+## 0.10.2
 
 - Don't check licenses of generated files in PR health workflow.
 - Add generalized ignore-per-checks to health workflow.
 - Update dart_apitool version in health workflow.
+- Print detailed info about the leaked APIs to stdout in the workflow.
 
 ## 0.10.1
 

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -305,8 +305,6 @@ class VerificationResults {
   bool get hasError => results.any((r) => r.severity == Severity.error);
 
   String describeAsMarkdown({bool withTag = true}) {
-    results.sort((a, b) => Enum.compareByIndex(a.severity, b.severity));
-
     return results.map((r) {
       var sev = r.severity == Severity.error ? '(error) ' : '';
       var tagColumn = '';

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -266,8 +266,8 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
 
     for (var package in packagesContaining(filesInPR)) {
       log('');
-      log('--- $package ---');
-      log('Look for leaks in $package');
+      log('--- ${package.name} ---');
+      log('Look for leaks in ${package.name}');
       var relativePath =
           path.relative(package.directory.path, from: directory.path);
       var tempDirectory = Directory.systemTemp.createTempSync();
@@ -298,21 +298,28 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
         arguments,
       );
 
+      log('');
+
       if (runApiTool.exitCode == 0) {
         var fullReportString = await File(reportPath).readAsString();
         var decoded = jsonDecode(fullReportString) as Map<String, dynamic>;
         var leaks = decoded['missingEntryPoints'] as List<dynamic>;
 
         if (leaks.isNotEmpty) {
-          final desc = leaks.map((item) => '$item').join(', ');
-          log('Leaking symbols in API: $desc.');
-
           leaksForPackage[package] = leaks.cast();
 
-          final report = const JsonEncoder.withIndent('  ').convert(decoded);
+          final desc = leaks.map((item) => '$item').join(', ');
+          log('Leaked symbols found: $desc.');
+
           log('');
+
+          final report = const JsonEncoder.withIndent('  ').convert(decoded);
           log(report);
+        } else {
+          log('No leaks found.');
         }
+
+        log('');
       } else {
         throw ProcessException(
           executable(flutterPackages.contains(package)),

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -173,6 +173,7 @@ class Health {
           ...['-sgit', 'https://github.com/bmw-tech/dart_apitool.git'],
           ...['--git-ref', apiToolHash],
         ],
+        logStdout: false,
       );
 
       runDashProcess(
@@ -223,7 +224,11 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
   String getCurrentVersionOfPackage(Package package) => 'pub://${package.name}';
 
   ProcessResult runDashProcess(
-      List<Package> flutterPackages, Package package, List<String> arguments) {
+    List<Package> flutterPackages,
+    Package package,
+    List<String> arguments, {
+    bool logStdout = true,
+  }) {
     var exec = executable(flutterPackages.any((p) => p.name == package.name));
     log('Running `$exec ${arguments.join(' ')}` in ${directory.path}');
     var runApiTool = Process.runSync(
@@ -232,7 +237,7 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
       workingDirectory: directory.path,
     );
     final out = (runApiTool.stdout as String).trimRight();
-    if (out.isNotEmpty) {
+    if (logStdout && out.isNotEmpty) {
       print(out);
     }
     final err = (runApiTool.stderr as String).trimRight();
@@ -283,6 +288,7 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
           ...['-sgit', 'https://github.com/bmw-tech/dart_apitool.git'],
           ...['--git-ref', apiToolHash],
         ],
+        logStdout: false,
       );
 
       var arguments = [

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -231,8 +231,14 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
       arguments,
       workingDirectory: directory.path,
     );
-    log('StdOut:\n ${runApiTool.stdout as String}');
-    log('StdErr:\n ${runApiTool.stderr as String}');
+    final out = (runApiTool.stdout as String).trimRight();
+    if (out.isNotEmpty) {
+      print(out);
+    }
+    final err = (runApiTool.stderr as String).trimRight();
+    if (err.isNotEmpty) {
+      print(err);
+    }
     return runApiTool;
   }
 
@@ -257,7 +263,10 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
     final flutterPackages =
         packagesContaining(filesInPR, only: flutterPackageGlobs);
     log('This list of Flutter packages is $flutterPackages');
+
     for (var package in packagesContaining(filesInPR)) {
+      log('');
+      log('--- $package ---');
       log('Look for leaks in $package');
       var relativePath =
           path.relative(package.directory.path, from: directory.path);
@@ -294,9 +303,15 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
         var decoded = jsonDecode(fullReportString) as Map<String, dynamic>;
         var leaks = decoded['missingEntryPoints'] as List<dynamic>;
 
-        log('Leaking symbols in API:\n$leaks');
         if (leaks.isNotEmpty) {
+          final desc = leaks.map((item) => '$item').join(', ');
+          log('Leaking symbols in API: $desc.');
+
           leaksForPackage[package] = leaks.cast();
+
+          final report = const JsonEncoder.withIndent('  ').convert(decoded);
+          log('');
+          log(report);
         }
       } else {
         throw ProcessException(

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.10.2-wip
+version: 0.10.2
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
- print detailed info about the leaked APIs to stdout in the workflow
- remove some (non-lexical) sorting from our publishing status makrdown table; with larger mono-repos, having the packages not be lexically ordered can be confusing
- rev the firehose package version and prep for publishing
- fix https://github.com/dart-lang/ecosystem/issues/333

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
