### PR TITLE
Add the discarded_futures lint; rev for publishing

### DIFF
--- a/.github/workflows/health_internal.yaml
+++ b/.github/workflows/health_internal.yaml
@@ -20,3 +20,5 @@ jobs:
       warn_on: license,coverage,breaking,leaking
       ignore_license: 'pkgs/firehose/test_data'
       ignore_coverage: 'pkgs/firehose/bin,pkgs/firehose/test_data'
+    permissions:
+      pull-requests: write

--- a/pkgs/dart_flutter_team_lints/CHANGELOG.md
+++ b/pkgs/dart_flutter_team_lints/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.0
+
+- Added `discarded_futures`.
+
 ## 3.4.0
 
 - Added `unnecessary_underscores`.

--- a/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
+++ b/pkgs/dart_flutter_team_lints/lib/analysis_options.yaml
@@ -44,6 +44,7 @@ linter:
     - avoid_dynamic_calls
     - comment_references
     - conditional_uri_does_not_exist
+    - discarded_futures
     - only_throw_errors
     - strict_top_level_inference
     - test_types_in_equals

--- a/pkgs/dart_flutter_team_lints/pubspec.yaml
+++ b/pkgs/dart_flutter_team_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flutter_team_lints
 description: An analysis rule set used by the Dart and Flutter teams.
-version: 3.4.0
+version: 3.5.0
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints
 issue_tracker: https://github.com/dart-lang/ecosystem/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Adart_flutter_team_lints
 


### PR DESCRIPTION
- Aad the `discarded_futures` lint
- rev for publishing

This is so we can dogfood `discarded_futures` on our own code to better eval the lint.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
