### PR TITLE
Update create_tuning_data.dart

### DIFF
--- a/pkgs/sdk_triage_bot/tool/create_tuning_data.dart
+++ b/pkgs/sdk_triage_bot/tool/create_tuning_data.dart
@@ -17,8 +17,9 @@ import 'package:sdk_triage_bot/src/prompts.dart';
 //   - make sure we have at least 10 items from each area
 
 const Map<String, int> areaSampleCount = {
-  'area-analyzer': 100,
   'area-core-library': 100,
+  'area-dart-model': 100,
+  'area-devexp': 100,
   'area-front-end': 100,
   'area-vm': 100,
   'area-web': 100,


### PR DESCRIPTION
The issues that used to be in `area-analyzer` have now been distributed between the two new areas, so this needs to be updated in order to get valid training data.