### PR TITLE
Fix tagging in publishing workflow (again)

### DIFF
--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
-    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags: [ '[A-z0-9]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -58,7 +58,7 @@ the tag pattern must be prefixed with the package name, e.g. `foo-v1.2.3`.
 - copy the yaml below into a `.github/workflows/publish.yaml` file in your repo
 - update the target branch below if necessary (currently, `main`)
 - if publishing from a mono-repo, adjust the 'tags' line below to
-  `tags: [ '[_0-9A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]`
+  `tags: [ '[0-9A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]`
 - from the pub.dev admin page of your package, enable publishing from GitHub
   Actions
 


### PR DESCRIPTION
Tags are not regexes...  https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
