### PR TITLE
[firehose] Fix dart_apitool invocations with pub workspaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             },
             "args": [
                 "--check",
-                "leaking"
+                "breaking"
             ],
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "health",
-            "program": "pkgs/firehose/bin/health.dart",
+            "program": "${workspaceFolder}/pkgs/firehose/bin/health.dart",
             "request": "launch",
             "type": "dart",
             "env": {
@@ -16,9 +16,10 @@
                 "GITHUB_STEP_SUMMARY": "/tmp/github_step_summary_mock.md",
             },
             "args": [
-                "--checks",
-                "version,changelog,license,coverage,do-not-submit,leaking"
-            ]
+                "--check",
+                "leaking"
+            ],
+            // "cwd": "/Users/dacoharkes/src/dart-lang/native/pkgs/native_assets_cli"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,6 @@
                 "--check",
                 "leaking"
             ],
-            // "cwd": "/Users/dacoharkes/src/dart-lang/native/pkgs/native_assets_cli"
         }
     ]
 }

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-wip
+## 0.10.3
 
 - Fix dart_apitool invocation in pub workspaces.
 

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.0-wip
 
+- Fix dart_apitool invocation in pub workspaces.
+
 ## 0.10.2
 
 - Don't check licenses of generated files in PR health workflow.

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -273,8 +273,7 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
       log('');
       log('--- ${package.name} ---');
       log('Look for leaks in ${package.name}');
-      var relativePath =
-          path.relative(package.directory.path, from: directory.path);
+      final absolutePath = package.directory.path;
       var tempDirectory = Directory.systemTemp.createTempSync();
       var reportPath = path.join(tempDirectory.path, 'leaks.json');
 
@@ -295,7 +294,7 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
         ...['pub', 'global', 'run'],
         'dart_apitool:main',
         'extract',
-        ...['--input', relativePath],
+        ...['--input', absolutePath],
         ...['--output', reportPath],
       ];
       var runApiTool = runDashProcess(

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -158,8 +158,7 @@ class Health {
     log('This list of Flutter packages is $flutterPackages');
     for (var package in packagesContaining(filesInPR, ignore: ignored)) {
       log('Look for changes in $package');
-      var relativePath =
-          path.relative(package.directory.path, from: directory.path);
+      final absolutePath = package.directory.absolute.path;
       var tempDirectory = Directory.systemTemp.createTempSync();
       var reportPath = path.join(tempDirectory.path, 'report.json');
 
@@ -185,7 +184,7 @@ class Health {
           'diff',
           '--no-check-sdk-version',
           ...['--old', getCurrentVersionOfPackage(package)],
-          ...['--new', relativePath],
+          ...['--new', absolutePath],
           ...['--report-format', 'json'],
           ...['--report-file-path', reportPath],
         ],

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -273,7 +273,7 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
       log('');
       log('--- ${package.name} ---');
       log('Look for leaks in ${package.name}');
-      final absolutePath = package.directory.path;
+      final absolutePath = package.directory.absolute.path;
       var tempDirectory = Directory.systemTemp.createTempSync();
       var reportPath = path.join(tempDirectory.path, 'leaks.json');
 

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 1.0.0-wip
+version: 0.10.3
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
Closes: https://github.com/dart-lang/ecosystem/issues/354

The `dart_apitool` interprets the `.` as a package, instead of a relative path to cwd.

Tested locally with the debugger command in `launch.json` (pointing to the code that was failing via `"cwd": "/Users/dacoharkes/src/dart-lang/native/pkgs/native_assets_cli"`).