### PR TITLE
[firehose] don't fail publish validation if we see the pub pre-release warning

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.4
+
+- Don't fail publish validations from Pub's pre-release package warning (see
+  https://github.com/dart-lang/pub/issues/3807).
+
 ## 0.10.3
 
 - Fix dart_apitool invocation in pub workspaces.

--- a/pkgs/firehose/lib/src/utils.dart
+++ b/pkgs/firehose/lib/src/utils.dart
@@ -10,7 +10,7 @@ import 'dart:io';
 ///
 /// This will also echo the command being run to stdout and indent the processes
 /// output slightly.
-Future<int> runCommand(
+Future<CommandResult> runCommand(
   String command, {
   List<String> args = const [],
   Directory? cwd,
@@ -23,12 +23,17 @@ Future<int> runCommand(
     workingDirectory: cwd?.path,
   );
 
+  final buffer = StringBuffer();
+
   process.stdout
       .transform(utf8.decoder)
       .transform(const LineSplitter())
-      .listen((line) => stdout
-        ..write('  ')
-        ..writeln(line));
+      .listen((line) {
+    buffer.writeln(line);
+    stdout
+      ..write('  ')
+      ..writeln(line);
+  });
   process.stderr
       .transform(utf8.decoder)
       .transform(const LineSplitter())
@@ -36,7 +41,19 @@ Future<int> runCommand(
         ..write('  ')
         ..writeln(line));
 
-  return process.exitCode;
+  final code = await process.exitCode;
+
+  return CommandResult(
+    code: code,
+    stdout: buffer.toString(),
+  );
+}
+
+class CommandResult {
+  final int code;
+  final String stdout;
+
+  CommandResult({required this.code, required this.stdout});
 }
 
 class Tag {

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to automate publishing of Pub packages from GitHub actions.
-version: 0.10.3
+version: 0.10.4
 repository: https://github.com/dart-lang/ecosystem/tree/main/pkgs/firehose
 
 environment:


### PR DESCRIPTION
- don't fail publish validation if we see the pub pre-release warning
- related to https://github.com/dart-lang/pub/issues/3807

This is a hammer, and can possibly let some validation issues be ignored now, but without this we'll fail every PR in every mono-repo that has a preview version of a package (a stable version that requires to next sdk version). We've hit this on several releases of package:lints.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
