### PR TITLE
run the health checks in fewer github jobs

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -12,8 +12,7 @@ name: Health
 # jobs:
 #   health:
 #     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
-
-
+#
 # Or with options:
 #
 # jobs:
@@ -148,12 +147,11 @@ on:
         required: false
 
 jobs:
-  changelog:
-    if: ${{ contains(inputs.checks, 'changelog') }}
+  health_checks:
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
-      check: changelog
+      check: ${{ inputs.checks }}
       fail_on: ${{ inputs.fail_on }}
       warn_on: ${{ inputs.warn_on }}
       local_debug: ${{ inputs.local_debug }}
@@ -163,86 +161,8 @@ jobs:
       checkout_submodules: ${{ inputs.checkout_submodules }}
       health_yaml_name: ${{ inputs.health_yaml_name }}
 
-  license:
-    if: ${{ contains(inputs.checks, 'license') }}
-    uses: ./.github/workflows/health_base.yaml
-    with:
-      sdk: ${{ inputs.sdk }}
-      check: license
-      fail_on: ${{ inputs.fail_on }}
-      warn_on: ${{ inputs.warn_on }}
-      local_debug: ${{ inputs.local_debug }}
-      flutter_packages: ${{ inputs.flutter_packages }}
-      ignore_license: ${{ inputs.ignore_license }}
-      ignore_packages: ${{ inputs.ignore_packages }}
-      checkout_submodules: ${{ inputs.checkout_submodules }}
-      health_yaml_name: ${{ inputs.health_yaml_name }}
-
-  coverage:
-    if: ${{ contains(inputs.checks, 'coverage') }}
-    uses: ./.github/workflows/health_base.yaml
-    with:
-      sdk: ${{ inputs.sdk }}
-      check: coverage
-      fail_on: ${{ inputs.fail_on }}
-      warn_on: ${{ inputs.warn_on }}
-      upload_coverage: ${{ inputs.upload_coverage }}
-      coverage_web: ${{ inputs.coverage_web }}
-      local_debug: ${{ inputs.local_debug }}
-      flutter_packages: ${{ inputs.flutter_packages }}
-      ignore_coverage: ${{ inputs.ignore_coverage }}
-      ignore_packages: ${{ inputs.ignore_packages }}
-      checkout_submodules: ${{ inputs.checkout_submodules }}
-      experiments: ${{ inputs.experiments }}
-      health_yaml_name: ${{ inputs.health_yaml_name }}
-
-  breaking:
-    if: ${{ contains(inputs.checks, 'breaking') }}
-    uses: ./.github/workflows/health_base.yaml
-    with:
-      sdk: ${{ inputs.sdk }}
-      check: breaking
-      fail_on: ${{ inputs.fail_on }}
-      warn_on: ${{ inputs.warn_on }}
-      local_debug: ${{ inputs.local_debug }}
-      flutter_packages: ${{ inputs.flutter_packages }}
-      ignore_breaking: ${{ inputs.ignore_breaking }}
-      ignore_packages: ${{ inputs.ignore_packages }}
-      checkout_submodules: ${{ inputs.checkout_submodules }}
-      health_yaml_name: ${{ inputs.health_yaml_name }}
-
-  do-not-submit:
-    if: ${{ contains(inputs.checks, 'do-not-submit') }}
-    uses: ./.github/workflows/health_base.yaml
-    with:
-      sdk: ${{ inputs.sdk }}
-      check: do-not-submit
-      fail_on: ${{ inputs.fail_on }}
-      warn_on: ${{ inputs.warn_on }}
-      local_debug: ${{ inputs.local_debug }}
-      flutter_packages: ${{ inputs.flutter_packages }}
-      ignore_donotsubmit: ${{ inputs.ignore_donotsubmit }}
-      ignore_packages: ${{ inputs.ignore_packages }}
-      checkout_submodules: ${{ inputs.checkout_submodules }}
-      health_yaml_name: ${{ inputs.health_yaml_name }}
-
-  leaking:
-    if: ${{ contains(inputs.checks, 'leaking') }}
-    uses: ./.github/workflows/health_base.yaml
-    with:
-      sdk: ${{ inputs.sdk }}
-      check: leaking
-      fail_on: ${{ inputs.fail_on }}
-      warn_on: ${{ inputs.warn_on }}
-      local_debug: ${{ inputs.local_debug }}
-      flutter_packages: ${{ inputs.flutter_packages }}
-      ignore_leaking: ${{ inputs.ignore_leaking }}
-      ignore_packages: ${{ inputs.ignore_packages }}
-      checkout_submodules: ${{ inputs.checkout_submodules }}
-      health_yaml_name: ${{ inputs.health_yaml_name }}
-
   comment:
-    needs: [changelog, license, coverage, breaking, do-not-submit, leaking]
+    needs: [health_checks]
     if: always()
     # These permissions are required for us to create comments on PRs.
     permissions:

--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -2,7 +2,8 @@
 
 name: Health:Base
 
-# The workflow doing the checks for `health.yaml`. Not meant to be used externally.
+# The workflow doing the checks for `health.yaml`. Not meant to be used
+# externally.
 
 on:
   workflow_call:


### PR DESCRIPTION
- adjust the health check(s) so that they run in fewer github workflow jobs
- https://github.com/dart-lang/ecosystem/issues/307

Starting as a draft to see what the output looks like.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
