### PR TITLE
Relax assumptions on workspaces in firehose

### DIFF
--- a/pkgs/firehose/lib/src/repo.dart
+++ b/pkgs/firehose/lib/src/repo.dart
@@ -62,11 +62,8 @@ class Repository {
     if (pubspecFile.existsSync()) {
       var pubspec = yaml.loadYaml(pubspecFile.readAsStringSync()) as Map;
       var publishTo = pubspec['publish_to'] as String?;
-      if (publishTo != 'none' && !pubspec.containsKey('workspace')) {
+      if (publishTo != 'none') {
         packages.add(Package(directory, this));
-        // There is an assumption here that published, non-workspace packages do
-        // not contain nested published packages.
-        return;
       }
     }
     if (directory.existsSync()) {


### PR DESCRIPTION
This led to packages not being found in the `grpc-dart` repo. I think this should be fine, any packages which should not be checked can still be ignored in the `publish.yaml`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
