### PR TITLE
firehose: Fix formatter error message

### DIFF
--- a/pkgs/firehose/test_data/base_test_repo/pkgs/package1/pubspec.yaml
+++ b/pkgs/firehose/test_data/base_test_repo/pkgs/package1/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/base_test_repo/pkgs/package2/pubspec.yaml
+++ b/pkgs/firehose/test_data/base_test_repo/pkgs/package2/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/base_test_repo/pkgs/package3/pubspec.yaml
+++ b/pkgs/firehose/test_data/base_test_repo/pkgs/package3/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/base_test_repo/pkgs/package4/pubspec.yaml
+++ b/pkgs/firehose/test_data/base_test_repo/pkgs/package4/pubspec.yaml
@@ -12,6 +12,6 @@ dependencies:
   intl: any
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0
   http: any

--- a/pkgs/firehose/test_data/base_test_repo/pkgs/package5/pubspec.yaml
+++ b/pkgs/firehose/test_data/base_test_repo/pkgs/package5/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/test_repo/pkgs/package1/pubspec.yaml
+++ b/pkgs/firehose/test_data/test_repo/pkgs/package1/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/test_repo/pkgs/package2/pubspec.yaml
+++ b/pkgs/firehose/test_data/test_repo/pkgs/package2/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/test_repo/pkgs/package3/pubspec.yaml
+++ b/pkgs/firehose/test_data/test_repo/pkgs/package3/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/firehose/test_data/test_repo/pkgs/package4/pubspec.yaml
+++ b/pkgs/firehose/test_data/test_repo/pkgs/package4/pubspec.yaml
@@ -12,6 +12,6 @@ dependencies:
   intl: any
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0
   http: any

--- a/pkgs/firehose/test_data/test_repo/pkgs/package5/pubspec.yaml
+++ b/pkgs/firehose/test_data/test_repo/pkgs/package5/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   # path: ^1.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0


### PR DESCRIPTION
The associated analysis_options uses dart_flutter_team_lints

So dartfmt was logging a lot of errors. Fixes those

Also helped me find/fix https://github.com/dart-lang/dart_style/pull/1818
