### PR TITLE
Add signal-rerun job to health workflow

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -163,6 +163,35 @@ on:
         type: string
 
 jobs:
+  signal-rerun:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    # Because this workflow is called by other workflows, we need to make sure
+    # we only run this when the PR is in the current repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: github-actions[bot]
+          body-includes: '## PR Health'
+
+      - name: Update comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        if: steps.fc.outputs.comment-id != 0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }},
+              body: '## PR Health ⚠️\n\nHealth checks are rerunning. These details are out-of-date.'
+            });
+
   changelog:
     if: ${{ contains(inputs.checks, 'changelog') }}
     uses: ./.github/workflows/health_base.yaml

--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -212,7 +212,8 @@ jobs:
             --license "${INPUTS_LICENSE}" \
             --license_test_string "${INPUTS_LICENSE_TEST_STRING}"
 
-      - run: test -f current_repo/output/comment-${INPUTS_CHECK}.md || echo $'The ${INPUTS_CHECK} workflow has encountered an exception and did not complete.' >> current_repo/output/comment-${INPUTS_CHECK}.md
+      - name: Ensure comment file exists
+        run: test -f current_repo/output/comment-${INPUTS_CHECK}.md || echo $'The ${INPUTS_CHECK} workflow has encountered an exception and did not complete.' >> current_repo/output/comment-${INPUTS_CHECK}.md
         if: ${{ '$action_state' == 1 }}
         env:
           INPUTS_CHECK: ${{ inputs.check }}


### PR DESCRIPTION
- Add a job to update the PR health comment at the start of a run to indicate that checks are rerunning.

- Add a name to the fallback comment step in health_base.yaml for better visibility in logs.
