### PR TITLE
fix(workflows): prevent duplicate PR comments in post_summaries.yaml

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -329,7 +329,7 @@ jobs:
       - name: Merge all single comments
         run: |
          mkdir output
-         echo $'## PR Health \n\n' >> output/comment.md
+         echo $'## PR Health\n\n' >> output/comment.md
          find single-comments -name '*.md' -exec cat {} + >> output/comment.md
          echo ${{ github.event.number }} > output/issueNumber
 

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -63,6 +63,8 @@ jobs:
             var fs = require('fs');
             if (fs.existsSync('./comment.md')) {
               var markdown = fs.readFileSync('./comment.md', 'utf8');
+              var firstLine = markdown.split('\n')[0];
+              
               if (fs.existsSync('./commentId')) {
                 var comment_number = Number(fs.readFileSync('./commentId', 'utf8'));
             
@@ -74,13 +76,33 @@ jobs:
                 });
               } else {
                 var issue_number = Number(fs.readFileSync('./issueNumber', 'utf8'));
-            
-                await github.rest.issues.createComment({
+                
+                const comments = await github.rest.issues.listComments({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue_number,
-                  body: markdown
                 });
+                
+                const existingComment = comments.data.find(c => 
+                  c.user.login === 'github-actions[bot]' && 
+                  c.body.startsWith(firstLine)
+                );
+                
+                if (existingComment) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existingComment.id,
+                    body: markdown
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue_number,
+                    body: markdown
+                  });
+                }
               }
             } else if (fs.existsSync('./commentId')) {
               var comment_number = Number(fs.readFileSync('./commentId', 'utf8'));

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -83,6 +83,7 @@ jobs:
                   issue_number: issue_number,
                 });
                 
+                // Fallback: Search for an existing comment with the same header.
                 const existingComment = comments.data.find(c => 
                   c.user.login === 'github-actions[bot]' && 
                   c.body.startsWith(firstLine)


### PR DESCRIPTION
Add a fallback search for existing comments in `post_summaries.yaml` before creating a new comment.

Previously, `health.yaml` searched for an existing comment and passed its ID to `post_summaries.yaml` via artifacts. However, if a new run of `Health` started before `post_summaries` from a previous run had finished posting the comment (due to the asynchronous nature of `workflow_run`), it wouldn't find the comment and would instruct `post_summaries` to create a new one, leading to duplicates.

Now, `post_summaries.yaml` will check if a comment with the same header (first line of the markdown) already exists on the PR, and update it if found, falling back to creating a new one only if no matching comment exists. This makes the commenting logic robust against race conditions between overlapping workflow runs.
