### PR TITLE
chore: inline find-comment/create-or-update-comment

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -55,13 +55,14 @@ jobs:
           mkdir -p output
           echo ${{ github.event.number }} > output/issueNumber
 
+      - name: Install firehose
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: fc
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: github-actions[bot]
-          body-includes: '## Ecosystem testing'
+        run: |
+          COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## Ecosystem testing")
+          echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Write comment id to file
         if: ${{ steps.fc.outputs.comment-id != 0 }} 

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -55,7 +55,12 @@ jobs:
           mkdir -p output
           echo ${{ github.event.number }} > output/issueNumber
 
-      - name: Install firehose
+      - name: Install firehose (internal)
+        if: github.repository == 'dart-lang/ecosystem'
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+
+      - name: Install firehose (external)
+        if: github.repository != 'dart-lang/ecosystem'
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
 
       - name: Find Comment

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -171,13 +171,14 @@ jobs:
     # we only run this when the PR is in the current repo.
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - uses: dart-lang/setup-dart@65eb853c3ba17dde3be364c3d2858773e7144260
+      - name: Install firehose
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: fc
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: github-actions[bot]
-          body-includes: '## PR Health'
+        run: |
+          COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## PR Health")
+          echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Update comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
@@ -311,6 +312,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: dart-lang/setup-dart@65eb853c3ba17dde3be364c3d2858773e7144260
+      - name: Install firehose
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
       - name: Download All Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -319,12 +323,10 @@ jobs:
       - run: ls -R single-comments
 
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: fc
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: github-actions[bot]
-          body-includes: '## PR Health'
+        run: |
+          COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## PR Health")
+          echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
       
       - name: Merge all single comments
         run: |

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -171,8 +171,12 @@ jobs:
     # we only run this when the PR is in the current repo.
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: dart-lang/setup-dart@65eb853c3ba17dde3be364c3d2858773e7144260
-      - name: Install firehose
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+      - name: Install firehose (internal)
+        if: github.repository == 'dart-lang/ecosystem'
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+      - name: Install firehose (external)
+        if: github.repository != 'dart-lang/ecosystem'
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
       - name: Find Comment
         id: fc
@@ -312,8 +316,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: dart-lang/setup-dart@65eb853c3ba17dde3be364c3d2858773e7144260
-      - name: Install firehose
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+      - name: Install firehose (internal)
+        if: github.repository == 'dart-lang/ecosystem'
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+      - name: Install firehose (external)
+        if: github.repository != 'dart-lang/ecosystem'
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
       - name: Download All Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -146,9 +146,13 @@ jobs:
         run: dart pub global activate coverage
         if: ${{ inputs.check == 'coverage' }}
 
-      - name: Install firehose
+      - name: Install firehose (internal)
+        if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+
+      - name: Install firehose (external)
+        if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
-        if: ${{ !inputs.local_debug }}
 
       - name: Install local firehose
         run: dart pub global activate --source path current_repo/pkgs/firehose/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,9 +137,13 @@ jobs:
         with:
           sdk: ${{ inputs.sdk }}
 
-      - name: Install firehose
+      - name: Install firehose (internal)
+        if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+
+      - name: Install firehose (external)
+        if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
-        if: ${{ !inputs.local_debug }}
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -233,9 +237,13 @@ jobs:
         with:
           sdk: ${{ inputs.sdk }}
 
-      - name: Install firehose
+      - name: Install firehose (internal)
+        if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+
+      - name: Install firehose (external)
+        if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
-        if: ${{ !inputs.local_debug }}
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -179,21 +179,13 @@ jobs:
           echo "comment=$COMMENT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (steps.comment-id.outputs.comment == '') }}
         continue-on-error: true
-        with:
-          issue-number: ${{ github.event.number }}
-          body-path: "output/comment.md"
-          edit-mode: replace
+        run: dart pub global run firehose:comment create-or-update --issue ${{ github.event.number }} --body-path output/comment.md
 
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (steps.comment-id.outputs.comment != '') }}
-        with:
-          comment-id: ${{ steps.comment-id.outputs.comment }}
-          body-path: "output/comment.md"
-          edit-mode: replace
+        run: dart pub global run firehose:comment create-or-update --comment-id ${{ steps.comment-id.outputs.comment }} --body-path output/comment.md
 
       - name: Save PR number
         if: ${{ !inputs.write-comments }}

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.13.2-wip
 
+- Inlined GitHub comment management into `firehose` as a first-class executable.
 - Echo any error output from dependencies task on failure 
   (avoids silent failures).
 - Give clear output when packages need a changelog update.

--- a/pkgs/firehose/bin/comment.dart
+++ b/pkgs/firehose/bin/comment.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:firehose/src/github.dart';
+
+Future<void> main(List<String> arguments) async {
+  final parser = _createArgParser();
+
+  late final ArgResults results;
+  try {
+    results = parser.parse(arguments);
+  } on ArgParserException catch (e) {
+    stderr.writeln(e.message);
+    exitCode = 64;
+    return;
+  }
+
+  final command = results.command;
+
+  if (command == null) {
+    stderr.writeln('Usage: comment <command> [options]');
+    stderr.writeln(parser.usage);
+    stderr.writeln('\nAvailable commands:');
+    for (final cmd in parser.commands.keys) {
+      stderr.writeln('  $cmd');
+    }
+    exitCode = 64;
+    return;
+  }
+
+  if (command.name == 'find') {
+    await _findComment(command);
+  } else if (command.name == 'create-or-update') {
+    await _createOrUpdateComment(command);
+  }
+}
+
+ArgParser _createArgParser() {
+  final parser = ArgParser();
+
+  parser.addCommand('find')
+    ..addOption('issue', help: 'PR or issue number', mandatory: true)
+    ..addOption('author',
+        help: 'Comment author', defaultsTo: 'github-actions[bot]')
+    ..addOption('body-includes', help: 'String to search for in comment body');
+
+  parser.addCommand('create-or-update')
+    ..addOption('issue', help: 'PR or issue number')
+    ..addOption('comment-id', help: 'Existing comment ID to update')
+    ..addOption('body', help: 'Comment body text')
+    ..addOption('body-path', help: 'Path to file containing comment body');
+
+  return parser;
+}
+
+Future<void> _findComment(ArgResults results) async {
+  final issue = results['issue'] as String;
+  final author = results['author'] as String;
+  final bodyIncludes = results['body-includes'] as String?;
+
+  final issueNumber = int.tryParse(issue);
+  if (issueNumber == null) {
+    stderr.writeln('Invalid issue number: $issue');
+    exitCode = 64;
+    return;
+  }
+
+  final github = GithubApi(issueNumber: issueNumber);
+
+  final commentId = await github.findCommentId(
+    user: author,
+    searchTerm: bodyIncludes,
+  );
+
+  if (commentId != null) {
+    print(commentId);
+  } else {
+    print('0');
+  }
+}
+
+Future<void> _createOrUpdateComment(ArgResults results) async {
+  final issue = results['issue'] as String?;
+  final commentId = results['comment-id'] as String?;
+  var body = results['body'] as String?;
+  final bodyPath = results['body-path'] as String?;
+
+  if (bodyPath != null) {
+    try {
+      body = await File(bodyPath).readAsString();
+    } catch (e) {
+      stderr.writeln('Error reading body-path: $e');
+      exitCode = 1;
+      return;
+    }
+  }
+
+  if (body == null) {
+    stderr.writeln('Missing body or body-path');
+    exitCode = 64;
+    return;
+  }
+
+  final issueNumber = issue != null ? int.tryParse(issue) : null;
+  final github = GithubApi(issueNumber: issueNumber);
+
+  if (commentId != null && commentId != '0' && commentId.isNotEmpty) {
+    final id = int.tryParse(commentId);
+    if (id == null) {
+      stderr.writeln('Invalid comment ID: $commentId');
+      exitCode = 64;
+      return;
+    }
+    await github.updateComment(id, body);
+    print('Updated comment $id');
+  } else {
+    final resolvedIssueNumber = github.issueNumber;
+    if (resolvedIssueNumber == null) {
+      stderr.writeln('Missing issue number for create');
+      exitCode = 64;
+      return;
+    }
+    await github.createComment(resolvedIssueNumber, body);
+    print('Created comment');
+  }
+}

--- a/pkgs/firehose/bin/comment.dart
+++ b/pkgs/firehose/bin/comment.dart
@@ -58,9 +58,9 @@ ArgParser _createArgParser() {
 }
 
 Future<void> _findComment(ArgResults results) async {
-  final issue = results['issue'] as String;
-  final author = results['author'] as String;
-  final bodyIncludes = results['body-includes'] as String?;
+  final issue = results.option('issue') as String;
+  final author = results.option('author') as String;
+  final bodyIncludes = results.option('body-includes');
 
   final issueNumber = int.tryParse(issue);
   if (issueNumber == null) {
@@ -84,10 +84,10 @@ Future<void> _findComment(ArgResults results) async {
 }
 
 Future<void> _createOrUpdateComment(ArgResults results) async {
-  final issue = results['issue'] as String?;
-  final commentId = results['comment-id'] as String?;
-  var body = results['body'] as String?;
-  final bodyPath = results['body-path'] as String?;
+  final issue = results.option('issue');
+  final commentId = results.option('comment-id');
+  var body = results.option('body');
+  final bodyPath = results.option('body-path');
 
   if (bodyPath != null) {
     try {

--- a/pkgs/firehose/bin/comment.dart
+++ b/pkgs/firehose/bin/comment.dart
@@ -102,8 +102,8 @@ Future<void> _createOrUpdateComment(ArgResults results) async {
     }
   }
 
-  if (body == null) {
-    stderr.writeln('Missing body or body-path');
+  if (body == null || body.trim().isEmpty) {
+    stderr.writeln('Comment body cannot be empty');
     exitCode = 64;
     return;
   }

--- a/pkgs/firehose/bin/comment.dart
+++ b/pkgs/firehose/bin/comment.dart
@@ -70,16 +70,19 @@ Future<void> _findComment(ArgResults results) async {
   }
 
   final github = GithubApi(issueNumber: issueNumber);
+  try {
+    final commentId = await github.findCommentId(
+      user: author,
+      searchTerm: bodyIncludes,
+    );
 
-  final commentId = await github.findCommentId(
-    user: author,
-    searchTerm: bodyIncludes,
-  );
-
-  if (commentId != null) {
-    print(commentId);
-  } else {
-    print('0');
+    if (commentId != null) {
+      print(commentId);
+    } else {
+      print('0');
+    }
+  } finally {
+    github.close();
   }
 }
 
@@ -105,26 +108,38 @@ Future<void> _createOrUpdateComment(ArgResults results) async {
     return;
   }
 
-  final issueNumber = issue != null ? int.tryParse(issue) : null;
+  int? issueNumber;
+  if (issue != null) {
+    issueNumber = int.tryParse(issue);
+    if (issueNumber == null) {
+      stderr.writeln('Invalid issue number: $issue');
+      exitCode = 64;
+      return;
+    }
+  }
   final github = GithubApi(issueNumber: issueNumber);
 
-  if (commentId != null && commentId != '0' && commentId.isNotEmpty) {
-    final id = int.tryParse(commentId);
-    if (id == null) {
-      stderr.writeln('Invalid comment ID: $commentId');
-      exitCode = 64;
-      return;
+  try {
+    if (commentId != null && commentId != '0' && commentId.isNotEmpty) {
+      final id = int.tryParse(commentId);
+      if (id == null) {
+        stderr.writeln('Invalid comment ID: $commentId');
+        exitCode = 64;
+        return;
+      }
+      await github.updateComment(id, body);
+      print('Updated comment $id');
+    } else {
+      final resolvedIssueNumber = github.issueNumber;
+      if (resolvedIssueNumber == null) {
+        stderr.writeln('Missing issue number for create');
+        exitCode = 64;
+        return;
+      }
+      await github.createComment(resolvedIssueNumber, body);
+      print('Created comment');
     }
-    await github.updateComment(id, body);
-    print('Updated comment $id');
-  } else {
-    final resolvedIssueNumber = github.issueNumber;
-    if (resolvedIssueNumber == null) {
-      stderr.writeln('Missing issue number for create');
-      exitCode = 64;
-      return;
-    }
-    await github.createComment(resolvedIssueNumber, body);
-    print('Created comment');
+  } finally {
+    github.close();
   }
 }

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -107,6 +107,14 @@ class GithubApi {
     return matchingComment?.id;
   }
 
+  Future<void> createComment(int issueNumber, String body) async {
+    await _github.issues.createComment(repoSlug!, issueNumber, body);
+  }
+
+  Future<void> updateComment(int commentId, String body) async {
+    await _github.issues.updateComment(repoSlug!, commentId, body);
+  }
+
   Future<List<GitFile>> listFilesForPR(
     Directory directory, [
     List<Glob> ignoredFiles = const [],

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -50,9 +50,18 @@ class GithubApi {
         'GITHUB_REPOSITORY environment variable is not set.',
       ));
 
+  late final int? _resolvedIssueNumber = _issueNumber ??
+      (switch (_env['ISSUE_NUMBER']) {
+        final s? => int.tryParse(s),
+        _ => null,
+      });
+
   /// The PR (or issue) number.
-  int? get issueNumber =>
-      _issueNumber ?? int.tryParse(_env['ISSUE_NUMBER'] ?? '');
+  int? get issueNumber => _resolvedIssueNumber;
+
+  int get _issue =>
+      _resolvedIssueNumber ??
+      (throw StateError('ISSUE_NUMBER environment variable is not set.'));
 
   /// Any labels applied to this PR.
   List<String> get prLabels =>
@@ -101,7 +110,7 @@ class GithubApi {
     String? searchTerm,
   }) async {
     final matchingComment = await _github.issues
-        .listCommentsByIssue(_slug, issueNumber!)
+        .listCommentsByIssue(_slug, _issue)
         .map<IssueComment?>((comment) => comment)
         .firstWhere(
       (comment) {
@@ -128,7 +137,7 @@ class GithubApi {
     List<Glob> ignoredFiles = const [],
   ]) async =>
       await _github.pullRequests
-          .listFiles(_slug, issueNumber!)
+          .listFiles(_slug, _issue)
           .map((prFile) => GitFile(
                 prFile.filename!,
                 FileStatus.fromString(prFile.status!),
@@ -170,7 +179,7 @@ class GithubApi {
   }
 
   Future<String> pullrequestBody() async {
-    final pullRequest = await _github.pullRequests.get(_slug, issueNumber!);
+    final pullRequest = await _github.pullRequests.get(_slug, _issue);
     return pullRequest.body ?? '';
   }
 

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -35,12 +35,20 @@ class GithubApi {
 
   String? get githubAuthToken => _env['GITHUB_TOKEN'];
 
+  late final RepositorySlug? _resolvedSlug = _repoSlug ??
+      (switch (_env['GITHUB_REPOSITORY']) {
+        final s? => RepositorySlug.full(s),
+        _ => null,
+      });
+
   /// The owner and repository name. For example, `octocat/Hello-World`.
-  RepositorySlug? get repoSlug =>
-      _repoSlug ??
-      (_env['GITHUB_REPOSITORY'] != null
-          ? RepositorySlug.full(_env['GITHUB_REPOSITORY']!)
-          : null);
+  RepositorySlug? get repoSlug => _resolvedSlug;
+
+  RepositorySlug get _slug =>
+      _resolvedSlug ??
+      (throw StateError(
+        'GITHUB_REPOSITORY environment variable is not set.',
+      ));
 
   /// The PR (or issue) number.
   int? get issueNumber =>
@@ -93,7 +101,7 @@ class GithubApi {
     String? searchTerm,
   }) async {
     final matchingComment = await _github.issues
-        .listCommentsByIssue(repoSlug!, issueNumber!)
+        .listCommentsByIssue(_slug, issueNumber!)
         .map<IssueComment?>((comment) => comment)
         .firstWhere(
       (comment) {
@@ -108,11 +116,11 @@ class GithubApi {
   }
 
   Future<void> createComment(int issueNumber, String body) async {
-    await _github.issues.createComment(repoSlug!, issueNumber, body);
+    await _github.issues.createComment(_slug, issueNumber, body);
   }
 
   Future<void> updateComment(int commentId, String body) async {
-    await _github.issues.updateComment(repoSlug!, commentId, body);
+    await _github.issues.updateComment(_slug, commentId, body);
   }
 
   Future<List<GitFile>> listFilesForPR(
@@ -120,7 +128,7 @@ class GithubApi {
     List<Glob> ignoredFiles = const [],
   ]) async =>
       await _github.pullRequests
-          .listFiles(repoSlug!, issueNumber!)
+          .listFiles(_slug, issueNumber!)
           .map((prFile) => GitFile(
                 prFile.filename!,
                 FileStatus.fromString(prFile.status!),
@@ -162,7 +170,7 @@ class GithubApi {
   }
 
   Future<String> pullrequestBody() async {
-    final pullRequest = await _github.pullRequests.get(repoSlug!, issueNumber!);
+    final pullRequest = await _github.pullRequests.get(_slug, issueNumber!);
     return pullRequest.body ?? '';
   }
 

--- a/pkgs/firehose/lib/src/local_github_api.dart
+++ b/pkgs/firehose/lib/src/local_github_api.dart
@@ -35,6 +35,16 @@ class LocalGithubApi implements GithubApi {
   }
 
   @override
+  Future<void> createComment(int issueNumber, String body) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> updateComment(int commentId, String body) async {
+    throw UnimplementedError();
+  }
+
+  @override
   String? get githubAuthToken => throw UnimplementedError();
 
   @override

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 executables:
   firehose: firehose
   health: health
+  comment: comment
 
 dependencies:
   args: ^2.3.0


### PR DESCRIPTION
Some Google repos don't like actions from "outside the enterprise"

Other fixes:

- Updated the logic to pull in `firehose` during PRs to THIS repo, so they can be validated together.
  - I think we had issues previously before this was NOT done so we landed firehose fixes blind
  - Sadly, it's pretty verbose. 
- Improved the robustness of the `github.dart` file
  - General wise handling of `null` bits to give helpful errors

Partially addresses https://github.com/dart-lang/ecosystem/issues/395
 
