### PR TITLE
fix(firehose): skip changelog and breaking changes checks for unpublished packages

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Skip changelog and breaking changes checks for unpublished packages.
 - Echo any error output from dependencies task on failure
-
   (avoids silent failures).
 - Give clear output when packages need a changelog update.
 - Support `%YEAR%` wildcard in the license check string.

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.13.2-wip
 
+- Skip changelog and breaking changes checks for unpublished packages.
 - Echo any error output from dependencies task on failure
+
   (avoids silent failures).
 - Give clear output when packages need a changelog update.
 - Support `%YEAR%` wildcard in the license check string.

--- a/pkgs/firehose/lib/src/health/changelog.dart
+++ b/pkgs/firehose/lib/src/health/changelog.dart
@@ -23,12 +23,13 @@ Future<Map<Package, List<GitFile>>> packagesWithoutChangelog(
   final files = await github.listFilesForPR(directory, ignored);
 
   final pool = Pool(10);
-  final publishedResults = await Future.wait(
-    packages.map((package) => pool.withResource(() async {
-          final published = await isPublished(package);
-          return (package, published);
-        })),
-  );
+  final publishedResults = await pool.forEach<Package, (Package, bool)>(
+    packages,
+    (package) async {
+      final published = await isPublished(package);
+      return (package, published);
+    },
+  ).toList();
 
   final publishedPackages = <Package>[];
   for (final (package, published) in publishedResults) {

--- a/pkgs/firehose/lib/src/health/changelog.dart
+++ b/pkgs/firehose/lib/src/health/changelog.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
 
+import 'package:pool/pool.dart';
+
 import '../github.dart';
 import '../repo.dart';
 
@@ -20,9 +22,17 @@ Future<Map<Package, List<GitFile>>> packagesWithoutChangelog(
   final packages = repo.locatePackages(ignore: ignored);
   final files = await github.listFilesForPR(directory, ignored);
 
+  final pool = Pool(10);
+  final publishedResults = await Future.wait(
+    packages.map((package) => pool.withResource(() async {
+          final published = await isPublished(package);
+          return (package, published);
+        })),
+  );
+
   final publishedPackages = <Package>[];
-  for (final package in packages) {
-    if (await isPublished(package)) {
+  for (final (package, published) in publishedResults) {
+    if (published) {
       publishedPackages.add(package);
     } else {
       print('Package ${package.name} is not published yet. '

--- a/pkgs/firehose/lib/src/health/changelog.dart
+++ b/pkgs/firehose/lib/src/health/changelog.dart
@@ -13,15 +13,26 @@ import '../repo.dart';
 Future<Map<Package, List<GitFile>>> packagesWithoutChangelog(
   GithubApi github,
   List<Glob> ignored,
-  Directory directory,
-) async {
+  Directory directory, {
+  required Future<bool> Function(Package) isPublished,
+}) async {
   final repo = Repository(directory);
   final packages = repo.locatePackages(ignore: ignored);
   final files = await github.listFilesForPR(directory, ignored);
 
+  final publishedPackages = <Package>[];
+  for (final package in packages) {
+    if (await isPublished(package)) {
+      publishedPackages.add(package);
+    } else {
+      print('Package ${package.name} is not published yet. '
+          'Skipping changelog check.');
+    }
+  }
+
   final packagesWithoutChangedChangelog =
       collectPackagesWithoutChangelogChanges(
-    packages,
+    publishedPackages,
     files,
     directory,
   );

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -255,14 +255,16 @@ For details on how to fix these, see [dependency_validator](https://pub.dev/pack
     log('This list of Flutter packages is $flutterPackages');
 
     final pool = Pool(10);
-    final packagesToCheck = <Package>[];
     final packages = packagesContaining(filesInPR, ignore: ignored);
-    final publishedStatuses = await Future.wait(
-      packages.map((package) => pool.withResource(() async {
-            final published = await isPublished(package);
-            return (package, published);
-          })),
-    );
+    final publishedStatuses = await pool.forEach<Package, (Package, bool)>(
+      packages,
+      (package) async {
+        final published = await isPublished(package);
+        return (package, published);
+      },
+    ).toList();
+
+    final packagesToCheck = <Package>[];
     for (final (package, published) in publishedStatuses) {
       if (published) {
         packagesToCheck.add(package);

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 
 import '../../firehose.dart';
+import '../pub.dart';
 import '../utils.dart';
 import 'changelog.dart';
 import 'coverage.dart';
@@ -252,6 +253,11 @@ For details on how to fix these, see [dependency_validator](https://pub.dev/pack
         packagesContaining(filesInPR, only: flutterPackageGlobs);
     log('This list of Flutter packages is $flutterPackages');
     for (final package in packagesContaining(filesInPR, ignore: ignored)) {
+      if (!await isPublished(package)) {
+        log('Package ${package.name} is not published yet. '
+            'Skipping breaking changes check.');
+        continue;
+      }
       log('Look for changes in $package');
       final absolutePath = package.directory.absolute.path;
       final tempDirectory = Directory.systemTemp.createTempSync();
@@ -331,6 +337,15 @@ ${changeForPackage.entries.map((e) => '|${e.key.name}|${e.value.toMarkdownRow()}
   }
 
   String getCurrentVersionOfPackage(Package package) => 'pub://${package.name}';
+
+  Future<bool> isPublished(Package package) async {
+    final pub = Pub();
+    try {
+      return await pub.isPublished(package.name);
+    } finally {
+      pub.close();
+    }
+  }
 
   (ProcessResult, String, String) runDashProcess(
     List<Package> flutterPackages,
@@ -514,6 +529,7 @@ ${unchangedFilesPaths.isNotEmpty ? unchangedMarkdown : ''}
       github,
       ignored,
       directory,
+      isPublished: isPublished,
     );
 
     final markdownResult = '''

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
+import 'package:pool/pool.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../../firehose.dart';
@@ -252,12 +253,26 @@ For details on how to fix these, see [dependency_validator](https://pub.dev/pack
     final flutterPackages =
         packagesContaining(filesInPR, only: flutterPackageGlobs);
     log('This list of Flutter packages is $flutterPackages');
-    for (final package in packagesContaining(filesInPR, ignore: ignored)) {
-      if (!await isPublished(package)) {
+
+    final pool = Pool(10);
+    final packagesToCheck = <Package>[];
+    final packages = packagesContaining(filesInPR, ignore: ignored);
+    final publishedStatuses = await Future.wait(
+      packages.map((package) => pool.withResource(() async {
+            final published = await isPublished(package);
+            return (package, published);
+          })),
+    );
+    for (final (package, published) in publishedStatuses) {
+      if (published) {
+        packagesToCheck.add(package);
+      } else {
         log('Package ${package.name} is not published yet. '
             'Skipping breaking changes check.');
-        continue;
       }
+    }
+
+    for (final package in packagesToCheck) {
       log('Look for changes in $package');
       final absolutePath = package.directory.absolute.path;
       final tempDirectory = Directory.systemTemp.createTempSync();

--- a/pkgs/firehose/lib/src/pub.dart
+++ b/pkgs/firehose/lib/src/pub.dart
@@ -13,7 +13,7 @@ class Pub {
   http.Client get httpClient => _httpClient ??= http.Client();
 
   Future<bool> hasPublishedVersion(String name, String version) async {
-    final uri = Uri.parse('https://pub.dev/api/packages/$name');
+    final uri = Uri.https('pub.dev', 'api/packages/$name');
     final response = await getCall(uri, retries: 3);
     if (response.statusCode != 200) {
       return false;
@@ -27,7 +27,7 @@ class Pub {
   }
 
   Future<bool> isPublished(String name) async {
-    final uri = Uri.parse('https://pub.dev/api/packages/$name');
+    final uri = Uri.https('pub.dev', 'api/packages/$name');
     final response = await getCall(uri, retries: 3);
     return response.statusCode == 200;
   }

--- a/pkgs/firehose/lib/src/pub.dart
+++ b/pkgs/firehose/lib/src/pub.dart
@@ -26,6 +26,12 @@ class Pub {
         .contains(version);
   }
 
+  Future<bool> isPublished(String name) async {
+    final uri = Uri.parse('https://pub.dev/api/packages/$name');
+    final response = await getCall(uri, retries: 3);
+    return response.statusCode == 200;
+  }
+
   Future<http.Response> getCall(Uri uri, {required int retries}) async {
     for (var i = 0; i < retries + 1; i++) {
       try {

--- a/pkgs/firehose/pubspec.yaml
+++ b/pkgs/firehose/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   glob: ^2.1.2
   http: ^1.0.0
   path: ^1.8.0
+  pool: ^1.5.2
   pub_semver: ^2.1.0
   pubspec_parse: ^1.2.3
   yaml: ^3.1.0

--- a/pkgs/firehose/test/health_test.dart
+++ b/pkgs/firehose/test/health_test.dart
@@ -173,4 +173,7 @@ class FakeHealth extends Health {
   @override
   String getCurrentVersionOfPackage(Package package) =>
       p.join('../base_test_repo/pkgs', package.name);
+
+  @override
+  Future<bool> isPublished(Package package) async => true;
 }

--- a/pkgs/firehose/test/pub_test.dart
+++ b/pkgs/firehose/test/pub_test.dart
@@ -36,6 +36,16 @@ void main() {
           'foo_bar_not_published_package', '1.8.0');
       expect(result, false);
     });
+
+    test('package is published', () async {
+      final result = await pub.isPublished('path');
+      expect(result, true);
+    });
+
+    test('package is not published', () async {
+      final result = await pub.isPublished('foo_bar_not_published_package');
+      expect(result, false);
+    });
   });
 
   group('VersionExtension', () {


### PR DESCRIPTION
- Add `isPublished` to `Pub` helper to query pub.dev status.
- Add `isPublished` callback/method to `Health` and parameterize `packagesWithoutChangelog`.
- Skip changelog checks in `packagesWithoutChangelog` for packages not yet published.
- Skip api-tool breaking change diff checks in `breakingCheck` for unpublished packages.
- Override `isPublished` in `FakeHealth` to return `true` so mock test packages continue to validate during health golden tests.
