### PR TITLE
Run `pub get` before `dart format` in groundskeeper

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.13.2-wip
 
+- Run `pub get` before `dart format` in `groundskeeper`.
+
 - Add `groundskeeper` executable to format and fix packages.
 - Add parameter to `locatePackages` to allow locating all packages with `publish_to: none`.
 - Inlined GitHub comment management into `firehose` as a first-class executable.

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.13.2-wip
 
 - Run `pub get` before `dart format` in `groundskeeper`.
-
 - Add `groundskeeper` executable to format and fix packages.
 - Add parameter to `locatePackages` to allow locating all packages with `publish_to: none`.
 - Inlined GitHub comment management into `firehose` as a first-class executable.

--- a/pkgs/firehose/bin/groundskeeper.dart
+++ b/pkgs/firehose/bin/groundskeeper.dart
@@ -15,6 +15,7 @@ void main(List<String> args) async {
   final argResults = parser.parse(args);
 
   final targetDirectory = Directory.current;
+  final pkgPath = targetDirectory.path;
   final runFormat = argResults['format'] != 'false';
   final runFix = argResults['fix'] != 'false';
 
@@ -31,23 +32,9 @@ Error: Run fix is enabled, but no pubspec.yaml found in ${targetDirectory.path}'
     exit(1);
   }
 
-  if (runFormat) {
-    print('Running dart format...');
-    final result = await Process.run(
-      'dart',
-      ['format', targetDirectory.path],
-    );
-    stdout.write(result.stdout);
-    stderr.write(result.stderr);
-    if (result.exitCode != 0) {
-      exit(result.exitCode);
-    }
-  }
-
-  if (runFix) {
+  if (isPackage) {
     final repo = Repository(targetDirectory);
     final pkg = Package(targetDirectory, repo);
-    final pkgPath = targetDirectory.path;
 
     // Detect if it is a Flutter package
     final isFlutter = pkg.pubspec.dependencies.containsKey('flutter') ||
@@ -65,7 +52,22 @@ Error: Run fix is enabled, but no pubspec.yaml found in ${targetDirectory.path}'
       print('Error: $tool pub get failed in $pkgPath');
       exit(pubGetResult.exitCode);
     }
+  }
 
+  if (runFormat) {
+    print('Running dart format...');
+    final result = await Process.run(
+      'dart',
+      ['format', pkgPath],
+    );
+    stdout.write(result.stdout);
+    stderr.write(result.stderr);
+    if (result.exitCode != 0) {
+      exit(result.exitCode);
+    }
+  }
+
+  if (runFix) {
     print('  Running dart fix --apply...');
     final fixResult = await Process.run('dart', ['fix', '--apply'],
         workingDirectory: pkgPath);


### PR DESCRIPTION
To avoid wrong formats.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
