### PR TITLE
Pass GITHUB_TOKEN to firehose:comment steps in workflows

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Find Comment
         id: fc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## Ecosystem testing")
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -180,6 +180,8 @@ jobs:
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
       - name: Find Comment
         id: fc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## PR Health")
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
@@ -332,6 +334,8 @@ jobs:
 
       - name: Find Comment
         id: fc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## PR Health")
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -186,10 +186,14 @@ jobs:
       - name: Create comment
         if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (steps.comment-id.outputs.comment == '') }}
         continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: dart pub global run firehose:comment create-or-update --issue ${{ github.event.number }} --body-path output/comment.md
 
       - name: Update comment
         if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (steps.comment-id.outputs.comment != '') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: dart pub global run firehose:comment create-or-update --comment-id ${{ steps.comment-id.outputs.comment }} --body-path output/comment.md
 
       - name: Save PR number


### PR DESCRIPTION
To not hit the API limit as easily.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
