### PR TITLE
Support configurable tag prefix in firehose and publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -146,7 +146,9 @@ jobs:
 
       - name: Install firehose (internal)
         if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+        env:
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -176,12 +178,18 @@ jobs:
           PR_LABELS: ${{ steps.fetch-labels.outputs.labels }}
           INPUTS_IGNORE_PACKAGES: ${{ inputs.ignore-packages }}
           INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
+          USE_FLUTTER: ${{ inputs.use-flutter }}
         run: |
+          if [ "$USE_FLUTTER" = "true" ]; then
+            FLUTTER_FLAG="--use-flutter"
+          else
+            FLUTTER_FLAG="--no-use-flutter"
+          fi
           dart pub global run firehose \
             --validate \
-            ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }} \
-            --ignore-packages "${INPUTS_IGNORE_PACKAGES}" \
-            --tag-prefix "${INPUTS_TAG_PREFIX}"
+            "$FLUTTER_FLAG" \
+            --ignore-packages "$INPUTS_IGNORE_PACKAGES" \
+            --tag-prefix "$INPUTS_TAG_PREFIX"
 
       - name: Get comment id
         id: comment-id
@@ -196,18 +204,22 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: dart pub global run firehose:comment create-or-update --issue ${{ github.event.number }} --body-path output/comment.md
+          ISSUE_NUMBER: ${{ github.event.number }}
+        run: dart pub global run firehose:comment create-or-update --issue "$ISSUE_NUMBER" --body-path output/comment.md
 
       - name: Update comment
         if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (steps.comment-id.outputs.comment != '') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: dart pub global run firehose:comment create-or-update --comment-id ${{ steps.comment-id.outputs.comment }} --body-path output/comment.md
+          COMMENT_ID: ${{ steps.comment-id.outputs.comment }}
+        run: dart pub global run firehose:comment create-or-update --comment-id "$COMMENT_ID" --body-path output/comment.md
 
       - name: Save PR number
         if: ${{ !inputs.write-comments }}
+        env:
+          ISSUE_NUMBER: ${{ github.event.number }}
         run: |
-          mkdir -p output/ && echo ${{ github.event.number }} > output/issueNumber
+          mkdir -p output/ && echo "$ISSUE_NUMBER" > output/issueNumber
 
       - name: Upload folder with number and markdown
         if: ${{ !inputs.write-comments }}
@@ -252,7 +264,9 @@ jobs:
 
       - name: Install firehose (internal)
         if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+        env:
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -265,8 +279,14 @@ jobs:
       - name: Publish packages
         env:
           INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
+          USE_FLUTTER: ${{ inputs.use-flutter }}
         run: |
+          if [ "$USE_FLUTTER" = "true" ]; then
+            FLUTTER_FLAG="--use-flutter"
+          else
+            FLUTTER_FLAG="--no-use-flutter"
+          fi
           dart pub global run firehose \
             --publish \
-            ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }} \
-            --tag-prefix "${INPUTS_TAG_PREFIX}"
+            "$FLUTTER_FLAG" \
+            --tag-prefix "$INPUTS_TAG_PREFIX"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,6 +98,12 @@ on:
         default: ''
         required: false
         type: string
+      tag-prefix:
+        description: >-
+          The prefix to expect and generate for release git tags (e.g. 'v' or '').
+        default: "v"
+        required: false
+        type: string
       local_debug:
         description: Whether to use a local copy of package:firehose - only for debug
         default: false
@@ -169,11 +175,13 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.number }}
           PR_LABELS: ${{ steps.fetch-labels.outputs.labels }}
           INPUTS_IGNORE_PACKAGES: ${{ inputs.ignore-packages }}
+          INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
         run: |
           dart pub global run firehose \
             --validate \
             ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }} \
-            --ignore-packages "${INPUTS_IGNORE_PACKAGES}"
+            --ignore-packages "${INPUTS_IGNORE_PACKAGES}" \
+            --tag-prefix "${INPUTS_TAG_PREFIX}"
 
       - name: Get comment id
         id: comment-id
@@ -255,4 +263,10 @@ jobs:
         if: ${{ inputs.local_debug }}
 
       - name: Publish packages
-        run: dart pub global run firehose --publish ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }}
+        env:
+          INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
+        run: |
+          dart pub global run firehose \
+            --publish \
+            ${{ fromJSON('{"true":"--use-flutter","false":"--no-use-flutter"}')[inputs.use-flutter] }} \
+            --tag-prefix "${INPUTS_TAG_PREFIX}"

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.13.2-wip
 
+- Add `--tag-prefix` option to `firehose` and `tag-prefix` input to `publish.yaml` to allow configuring the release tag prefix (defaults to `'v'`).
 - Run `pub get` before `dart format` in `groundskeeper`.
 - Add `groundskeeper` executable to format and fix packages.
 - Add parameter to `locatePackages` to allow locating all packages with `publish_to: none`.

--- a/pkgs/firehose/bin/firehose.dart
+++ b/pkgs/firehose/bin/firehose.dart
@@ -12,6 +12,7 @@ const helpFlag = 'help';
 const validateFlag = 'validate';
 const publishFlag = 'publish';
 const useFlutterFlag = 'use-flutter';
+const tagPrefixOption = 'tag-prefix';
 
 void main(List<String> arguments) async {
   final argParser = _createArgs();
@@ -26,6 +27,7 @@ void main(List<String> arguments) async {
     final validate = argResults[validateFlag] as bool;
     final publish = argResults[publishFlag] as bool;
     final useFlutter = argResults[useFlutterFlag] as bool;
+    final tagPrefix = argResults[tagPrefixOption] as String;
     final ignoredPackages = (argResults['ignore-packages'] as List<String>)
         .where((pattern) => pattern.isNotEmpty)
         .map((pattern) => Glob(pattern, recursive: true))
@@ -47,7 +49,12 @@ void main(List<String> arguments) async {
       return;
     }
 
-    final firehose = Firehose(Directory.current, useFlutter, ignoredPackages);
+    final firehose = Firehose(
+      Directory.current,
+      useFlutter,
+      ignoredPackages,
+      tagPrefix: tagPrefix,
+    );
 
     if (validate) {
       await firehose.validate();
@@ -94,6 +101,11 @@ ArgParser _createArgs() => ArgParser()
     useFlutterFlag,
     negatable: true,
     help: 'Whether this is a Flutter project.',
+  )
+  ..addOption(
+    tagPrefixOption,
+    defaultsTo: 'v',
+    help: 'The tag prefix to expect and generate (e.g. "v" or "").',
   )
   ..addMultiOption(
     'ignore-packages',

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -31,8 +31,14 @@ class Firehose {
   final Directory directory;
   final bool useFlutter;
   final List<Glob> ignoredPackages;
+  final String tagPrefix;
 
-  Firehose(this.directory, this.useFlutter, this.ignoredPackages);
+  Firehose(
+    this.directory,
+    this.useFlutter,
+    this.ignoredPackages, {
+    this.tagPrefix = 'v',
+  });
 
   /// Validate the packages in the repository.
   ///
@@ -109,7 +115,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     final results = VerificationResults();
 
     for (final package in packages) {
-      final repoTag = repo.calculateRepoTag(package);
+      final repoTag = repo.calculateRepoTag(package, tagPrefix: tagPrefix);
 
       print('');
       print('Validating $package:${package.name}');
@@ -172,7 +178,11 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
             package,
             '**ready to publish**',
             repoTag,
-            repo.calculateReleaseUri(package, github),
+            repo.calculateReleaseUri(
+              package,
+              github,
+              tagPrefix: tagPrefix,
+            ),
           );
           print(result);
           results.addResult(result);
@@ -206,7 +216,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     if (!expectEnv(github.refName, 'GITHUB_REF_NAME')) return false;
 
     // Validate the git tag.
-    final tag = Tag(github.refName!);
+    final tag = Tag(github.refName!, prefix: tagPrefix);
     if (!tag.valid) {
       stderr.writeln("Git tag not in expected format: '$tag'");
       return false;

--- a/pkgs/firehose/lib/src/repo.dart
+++ b/pkgs/firehose/lib/src/repo.dart
@@ -90,16 +90,20 @@ class Repository {
     }
   }
 
-  String calculateRepoTag(Package package) {
+  String calculateRepoTag(Package package, {String tagPrefix = 'v'}) {
     if (isSinglePackageRepo) {
-      return 'v${package.pubspec.version}';
+      return '$tagPrefix${package.pubspec.version}';
     } else {
-      return '${package.name}-v${package.pubspec.version}';
+      return '${package.name}-$tagPrefix${package.pubspec.version}';
     }
   }
 
-  Uri calculateReleaseUri(Package package, GithubApi github) {
-    final tag = calculateRepoTag(package);
+  Uri calculateReleaseUri(
+    Package package,
+    GithubApi github, {
+    String tagPrefix = 'v',
+  }) {
+    final tag = calculateRepoTag(package, tagPrefix: tagPrefix);
     final title = 'package:${package.name} v${package.pubspec.version}';
     final body = package.changelog.describeLatestChanges;
     return Uri.https('github.com', '/${github.repoSlug}/releases/new',

--- a/pkgs/firehose/lib/src/utils.dart
+++ b/pkgs/firehose/lib/src/utils.dart
@@ -59,9 +59,9 @@ class CommandResult {
 class Tag {
   /// RegExp matching a version tag at the start of a line.
   ///
-  /// A version tag is an optional starting seqeuence of non-whitespace, which
-  /// is the package name, followed by a `v` and a simplified SemVer version
-  /// number.
+  /// A version tag is an optional starting sequence of non-whitespace, which
+  /// is the package name, followed by [prefix] (defaulting to `'v'`) and a
+  /// simplified SemVer version number.
   ///
   /// The version number accepted is:
   ///
@@ -69,37 +69,40 @@ class Tag {
   ///
   /// and if followed by a `+` or `-`, then it includes the remaining
   /// non-whitespace characters.
-  static final RegExp packageVersionTag =
-      RegExp(r'^(?:(\S+)-)?v(\d+\.\d+\.\d+(?:[+\-]\S*)?)');
+  static RegExp packageVersionTag({String prefix = 'v'}) => RegExp(
+      '^(?:(\\S+)-)?${RegExp.escape(prefix)}(\\d+\\.\\d+\\.\\d+(?:[+\\-]\\S*)?)');
 
   /// A package version tag.
   ///
   /// Is expected to have the format:
   ///
-  /// > (package-name)? 'v' SemVer-version
+  /// > (package-name)? prefix SemVer-version
   ///
   /// If not, the tag is not [valid], and the [package] and [version] will both
   /// be `null`.
   final String tag;
+  final String prefix;
 
-  Tag(this.tag);
+  Tag(this.tag, {this.prefix = 'v'});
+
+  late final Match? _match = packageVersionTag(prefix: prefix).firstMatch(tag);
 
   bool get valid => version != null;
 
-  /// The package name before the `v` in the version [tag], if any.
+  /// The package name before the prefix in the version [tag], if any.
   ///
-  /// Is `null` if there is no package name before the `v`,
+  /// Is `null` if there is no package name before the prefix,
   /// or if the tag is not [valid].
-  String? get package => packageVersionTag.firstMatch(tag)?[1];
+  String? get package => _match?[1];
 
   /// The SemVer version string of the version [tag], if any.
   ///
-  /// This is the part after the `v` of the [tag] string,
+  /// This is the part after the prefix of the [tag] string,
   /// of the form, which is a major/minor/patch version string
   /// optionally followed by a `+` and more characters.
   ///
   /// Is `null` if the tag is not [valid].
-  String? get version => packageVersionTag.firstMatch(tag)?[2];
+  String? get version => _match?[2];
 
   @override
   String toString() => tag;

--- a/pkgs/firehose/test/repo_test.dart
+++ b/pkgs/firehose/test/repo_test.dart
@@ -65,6 +65,26 @@ void main() {
           allOf(contains(package.name), contains(package.version.toString())));
       expect(queryParams['body'], package.changelog.describeLatestChanges);
     });
+
+    test('github release link with custom prefix', () {
+      final github = GithubApi(
+        repoSlug: RepositorySlug.full('dart-lang/ecosystem'),
+      );
+      final package = packages.locatePackages().first;
+      final releaseUri = packages.calculateReleaseUri(
+        package,
+        github,
+        tagPrefix: '',
+      );
+      expect(releaseUri.path, '/${github.repoSlug}/releases/new');
+
+      final queryParams = releaseUri.queryParameters;
+      expect(
+        queryParams['tag'],
+        packages.calculateRepoTag(package, tagPrefix: ''),
+      );
+      expect(queryParams['tag'], '${package.name}-${package.pubspec.version}');
+    });
   });
 
   group('pub workspace repo', () {

--- a/pkgs/firehose/test/utils_test.dart
+++ b/pkgs/firehose/test/utils_test.dart
@@ -62,5 +62,40 @@ void main() {
       tag = Tag('foobar-1.2.3');
       expect(tag.valid, false);
     });
+
+    test('empty prefix single package repo', () {
+      final tag = Tag('1.2.3', prefix: '');
+      expect(tag.valid, true);
+      expect(tag.package, isNull);
+      expect(tag.version, '1.2.3');
+    });
+
+    test('empty prefix single package repo pre-release', () {
+      final tag = Tag('1.2.3-beta', prefix: '');
+      expect(tag.valid, true);
+      expect(tag.package, isNull);
+      expect(tag.version, '1.2.3-beta');
+    });
+
+    test('empty prefix mono repo', () {
+      final tag = Tag('foobar-1.2.3', prefix: '');
+      expect(tag.valid, true);
+      expect(tag.package, 'foobar');
+      expect(tag.version, '1.2.3');
+    });
+
+    test('custom prefix single package repo', () {
+      final tag = Tag('rel-1.2.3', prefix: 'rel-');
+      expect(tag.valid, true);
+      expect(tag.package, isNull);
+      expect(tag.version, '1.2.3');
+    });
+
+    test('custom prefix mono repo', () {
+      final tag = Tag('foobar-rel-1.2.3', prefix: 'rel-');
+      expect(tag.valid, true);
+      expect(tag.package, 'foobar');
+      expect(tag.version, '1.2.3');
+    });
   });
 }


### PR DESCRIPTION
Add support for configurable release tag prefixes in `package:firehose` and the reusable `publish.yaml` workflow.

This allows repositories that do not use the `'v'` prefix on git tags (e.g. raw `0.23.13` tags) to adopt `firehose` without needing to change their historical tag scheme.
