### PR TITLE
Grant required permissions in want_lgtm_internal and canary_internal workflows

### DIFF
--- a/.github/workflows/canary_internal.yaml
+++ b/.github/workflows/canary_internal.yaml
@@ -7,6 +7,8 @@ on:
         
 jobs:
   test_ecosystem:
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/canary.yaml
     with:
       repos_file: .github/test_repos/repos.json

--- a/.github/workflows/want_lgtm.yaml
+++ b/.github/workflows/want_lgtm.yaml
@@ -12,6 +12,9 @@ name: Want LGTM
 #     types: [submitted, edited, dismissed]
 # jobs:
 #   want-lgtm:
+#     permissions:
+#       pull-requests: read
+#       issues: read
 #     uses: dart-lang/ecosystem/.github/workflows/want_lgtm.yaml@main
 
 on:

--- a/.github/workflows/want_lgtm_internal.yaml
+++ b/.github/workflows/want_lgtm_internal.yaml
@@ -9,4 +9,7 @@ on:
 
 jobs:
   want_lgtm:
+    permissions:
+      pull-requests: read
+      issues: read
     uses: ./.github/workflows/want_lgtm.yaml


### PR DESCRIPTION
Fixes workflow validation errors by explicitly declaring required permissions:
- `want_lgtm_internal.yaml`: `pull-requests: read` and `issues: read`
- `canary_internal.yaml`: `pull-requests: write`