### PR TITLE
Support pull requests from forks and custom branches in CI workflows

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -15,6 +15,8 @@ on:
         
 jobs:
   test:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -51,20 +51,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUTS_REPOS_FILE: ${{ inputs.repos_file }}
-          GITHUB_REPOSITORY_URL: ${{ github.repositoryUrl }}
+          GITHUB_REPOSITORY_URL: ${{ github.event.pull_request.head.repo.clone_url || github.repositoryUrl }}
           HEAD_REF: ${{ github.head_ref || github.ref_name }}
           LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
 
       - name: Output issue number
+        env:
+          ISSUE_NUMBER: ${{ github.event.number }}
         run: |
           mkdir -p output
-          echo ${{ github.event.number }} > output/issueNumber
+          echo "$ISSUE_NUMBER" > output/issueNumber
 
       - name: Install firehose (internal)
         if: github.repository == 'dart-lang/ecosystem'
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$HEAD_REF"
         env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           HEAD_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$HEAD_REF"
 
       - name: Install firehose (external)
         if: github.repository != 'dart-lang/ecosystem'
@@ -74,8 +77,9 @@ jobs:
         id: fc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.number }}
         run: |
-          COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## Ecosystem testing")
+          COMMENT_ID=$(dart pub global run firehose:comment find --issue "$ISSUE_NUMBER" --author github-actions[bot] --body-includes "## Ecosystem testing")
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Write comment id to file

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -174,7 +174,10 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       - name: Install firehose (internal)
         if: github.repository == 'dart-lang/ecosystem'
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+        env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
       - name: Install firehose (external)
         if: github.repository != 'dart-lang/ecosystem'
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
@@ -182,8 +185,9 @@ jobs:
         id: fc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.number }}
         run: |
-          COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## PR Health")
+          COMMENT_ID=$(dart pub global run firehose:comment find --issue "$ISSUE_NUMBER" --author github-actions[bot] --body-includes "## PR Health")
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Update comment
@@ -321,7 +325,10 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       - name: Install firehose (internal)
         if: github.repository == 'dart-lang/ecosystem'
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+        env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
       - name: Install firehose (external)
         if: github.repository != 'dart-lang/ecosystem'
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
@@ -336,16 +343,19 @@ jobs:
         id: fc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.number }}
         run: |
-          COMMENT_ID=$(dart pub global run firehose:comment find --issue ${{ github.event.number }} --author github-actions[bot] --body-includes "## PR Health")
+          COMMENT_ID=$(dart pub global run firehose:comment find --issue "$ISSUE_NUMBER" --author github-actions[bot] --body-includes "## PR Health")
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
       
       - name: Merge all single comments
+        env:
+          ISSUE_NUMBER: ${{ github.event.number }}
         run: |
          mkdir output
          echo $'## PR Health\n\n' >> output/comment.md
          find single-comments -name '*.md' -exec cat {} + >> output/comment.md
-         echo ${{ github.event.number }} > output/issueNumber
+         echo "$ISSUE_NUMBER" > output/issueNumber
 
       - name: Write comment id to file
         if: ${{ steps.fc.outputs.comment-id != 0 }} 

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -207,6 +207,8 @@ jobs:
 
   changelog:
     if: ${{ contains(inputs.checks, 'changelog') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
@@ -222,6 +224,8 @@ jobs:
 
   license:
     if: ${{ contains(inputs.checks, 'license') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
@@ -239,6 +243,8 @@ jobs:
 
   coverage:
     if: ${{ contains(inputs.checks, 'coverage') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
@@ -257,6 +263,8 @@ jobs:
 
   breaking:
     if: ${{ contains(inputs.checks, 'breaking') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
@@ -272,6 +280,8 @@ jobs:
 
   do-not-submit:
     if: ${{ contains(inputs.checks, 'do-not-submit') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
@@ -287,6 +297,8 @@ jobs:
 
   leaking:
     if: ${{ contains(inputs.checks, 'leaking') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}
@@ -302,6 +314,8 @@ jobs:
 
   unused-dependencies:
     if: ${{ contains(inputs.checks, 'unused-dependencies') }}
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/health_base.yaml
     with:
       sdk: ${{ inputs.sdk }}

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -193,13 +193,15 @@ jobs:
       - name: Update comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         if: steps.fc.outputs.comment-id != 0
+        env:
+          COMMENT_ID: ${{ steps.fc.outputs.comment-id }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: ${{ steps.fc.outputs.comment-id }},
+              comment_id: process.env.COMMENT_ID,
               body: '## PR Health ⚠️\n\nHealth checks are rerunning. These details are out-of-date.'
             });
 

--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -148,7 +148,10 @@ jobs:
 
       - name: Install firehose (internal)
         if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref ${{ github.head_ref || github.ref_name }}
+        env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}

--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -197,11 +197,17 @@ jobs:
           INPUTS_HEALTH_YAML_NAME: ${{ inputs.health_yaml_name }}
           INPUTS_LICENSE: ${{ inputs.license }}
           INPUTS_LICENSE_TEST_STRING: ${{ inputs.license_test_string }}
+          INPUTS_COVERAGE_WEB: ${{ inputs.coverage_web }}
         run: |
           cd current_repo/
+          if [ "$INPUTS_COVERAGE_WEB" = "true" ]; then
+            COVERAGE_WEB_FLAG="--coverage_web"
+          else
+            COVERAGE_WEB_FLAG=""
+          fi
           dart pub global run firehose:health \
-            --check ${INPUTS_CHECK} \
-            ${{ fromJSON('{"true":"--coverage_web","false":""}')[inputs.coverage_web] }} \
+            --check "${INPUTS_CHECK}" \
+            $COVERAGE_WEB_FLAG \
             --fail_on "${INPUTS_FAIL_ON}" \
             --warn_on "${INPUTS_WARN_ON}" \
             --flutter_packages "${INPUTS_FLUTTER_PACKAGES}" \
@@ -221,7 +227,7 @@ jobs:
 
       - name: Ensure comment file exists
         run: test -f current_repo/output/comment-${INPUTS_CHECK}.md || echo $'The ${INPUTS_CHECK} workflow has encountered an exception and did not complete.' >> current_repo/output/comment-${INPUTS_CHECK}.md
-        if: ${{ '$action_state' == 1 }}
+        if: failure()
         env:
           INPUTS_CHECK: ${{ inputs.check }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -147,8 +147,9 @@ jobs:
       - name: Install firehose (internal)
         if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
         env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -265,8 +266,9 @@ jobs:
       - name: Install firehose (internal)
         if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
         env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}


### PR DESCRIPTION
When PRs are submitted from forks or non-main branches on internal workflows (`canary.yaml`, `health.yaml`, `health_base.yaml`, `publish.yaml`), installing `firehose` via `dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-ref "$HEAD_REF"` fails because the branch ref only exists on the head repository (e.g. the fork), not on upstream `dart-lang/ecosystem`.

### Changes
- Use the pull request's head repository clone URL (`github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem'`) when activating `firehose` from git.
- Pass `ISSUE_NUMBER`, `COMMENT_ID`, and `GIT_REF` via environment variables to prevent template injection warnings.
- Add explicit `permissions: pull-requests: write` blocks to caller jobs in `health.yaml` and `canary.yaml` to address Zizmor `excessive-permissions` findings.