### PR TITLE
[publish] Add experimental provenance input and flag for package signing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -333,7 +333,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          dart pub global run firehose \
+          unshare -r -n -- dart pub global run firehose \
             --package-only \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -245,13 +245,6 @@ jobs:
         with:
           submodules: ${{ inputs.checkout_submodules }}
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-cache-
-
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         if: ${{ inputs.use-flutter }}
         with:
@@ -303,13 +296,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: ${{ inputs.checkout_submodules }}
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-cache-
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         if: ${{ inputs.use-flutter }}
@@ -375,13 +361,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: ${{ inputs.checkout_submodules }}
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-cache-
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         if: ${{ inputs.use-flutter }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -346,7 +346,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          sudo unshare -n sudo -u $(whoami) -H env "PATH=$PATH" dart pub global run firehose \
+          sudo -E unshare -n sudo -u $(whoami) -E env "PATH=$PATH" "HOME=$HOME" dart pub global run firehose \
             --package-only \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -235,8 +235,73 @@ jobs:
           name: output
           path: output/
 
+  package:
+    if: ${{ github.event_name == 'push' && inputs.provenance }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-cache-
+
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        if: ${{ inputs.use-flutter }}
+        with:
+          channel: ${{ inputs.sdk }}
+          cache: true
+
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        if: ${{ !inputs.use-flutter }}
+        with:
+          sdk: ${{ inputs.sdk }}
+
+      - name: Install firehose (internal)
+        if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
+        env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+
+      - name: Install firehose (external)
+        if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+
+      - name: Install local firehose
+        run: dart pub global activate --source path pkgs/firehose/
+        if: ${{ inputs.local_debug }}
+
+      - name: Package archive for provenance
+        env:
+          INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
+          USE_FLUTTER: ${{ inputs.use-flutter }}
+        run: |
+          if [ "$USE_FLUTTER" = "true" ]; then
+            FLUTTER_FLAG="--use-flutter"
+          else
+            FLUTTER_FLAG="--no-use-flutter"
+          fi
+          dart pub global run firehose \
+            --package-only \
+            "$FLUTTER_FLAG" \
+            --tag-prefix "$INPUTS_TAG_PREFIX"
+
+      - name: Upload package archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.0.0
+        with:
+          name: package-archive
+          path: output/
+
   publish:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && !cancelled() && !failure() }}
+    needs: [package]
 
     # Require the github deployment environment if supplied.
     environment: ${{ inputs.environment }}
@@ -285,21 +350,12 @@ jobs:
         run: dart pub global activate --source path pkgs/firehose/
         if: ${{ inputs.local_debug }}
 
-      - name: Package archive for provenance
+      - name: Download package archive
         if: ${{ inputs.provenance }}
-        env:
-          INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
-          USE_FLUTTER: ${{ inputs.use-flutter }}
-        run: |
-          if [ "$USE_FLUTTER" = "true" ]; then
-            FLUTTER_FLAG="--use-flutter"
-          else
-            FLUTTER_FLAG="--no-use-flutter"
-          fi
-          dart pub global run firehose \
-            --package-only \
-            "$FLUTTER_FLAG" \
-            --tag-prefix "$INPUTS_TAG_PREFIX"
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: package-archive
+          path: output/
 
       - name: Generate Build Provenance
         if: ${{ inputs.provenance }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -104,6 +104,12 @@ on:
         default: "v"
         required: false
         type: string
+      provenance:
+        description: >-
+          Whether to enable package provenance signing (experimental).
+        default: false
+        required: false
+        type: boolean
       local_debug:
         description: Whether to use a local copy of package:firehose - only for debug
         default: false
@@ -235,9 +241,10 @@ jobs:
     # Require the github deployment environment if supplied.
     environment: ${{ inputs.environment }}
 
-    # This permission is required for authentication using OIDC.
+    # This permission is required for authentication using OIDC and for artifact attestations.
     permissions:
       id-token: write
+      attestations: write
 
     runs-on: ubuntu-latest
     steps:
@@ -282,13 +289,20 @@ jobs:
         env:
           INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
           USE_FLUTTER: ${{ inputs.use-flutter }}
+          PROVENANCE: ${{ inputs.provenance }}
         run: |
           if [ "$USE_FLUTTER" = "true" ]; then
             FLUTTER_FLAG="--use-flutter"
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
+          if [ "$PROVENANCE" = "true" ]; then
+            PROVENANCE_FLAG="--provenance"
+          else
+            PROVENANCE_FLAG=""
+          fi
           dart pub global run firehose \
             --publish \
             "$FLUTTER_FLAG" \
-            --tag-prefix "$INPUTS_TAG_PREFIX"
+            --tag-prefix "$INPUTS_TAG_PREFIX" \
+            $PROVENANCE_FLAG

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -148,8 +148,6 @@ jobs:
       pull-requests: write
 
     runs-on: ubuntu-latest
-    env:
-      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -182,6 +180,8 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
+        env:
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
@@ -263,8 +263,6 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    env:
-      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -290,6 +288,8 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
+        env:
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
@@ -317,8 +317,6 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    env:
-      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -344,6 +342,8 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
+        env:
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
@@ -384,8 +384,6 @@ jobs:
       attestations: write
 
     runs-on: ubuntu-latest
-    env:
-      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -411,6 +409,8 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
+        env:
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -131,12 +131,6 @@ on:
         default: "package-archive"
         required: false
         type: string
-      firehose_ref:
-        description: >-
-          The git ref to use when activating package:firehose from dart-lang/ecosystem.
-        default: "main"
-        required: false
-        type: string
       local_debug:
         description: Whether to use a local copy of package:firehose - only for debug
         default: false
@@ -187,7 +181,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -295,7 +289,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -349,7 +343,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -416,7 +410,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -110,6 +110,13 @@ on:
         default: false
         required: false
         type: boolean
+      skip-validation:
+        description: >-
+          Whether to skip the pre-release validation step. Useful if you run
+          your own custom validation before publishing.
+        default: false
+        required: false
+        type: boolean
       local_debug:
         description: Whether to use a local copy of package:firehose - only for debug
         default: false
@@ -236,7 +243,7 @@ jobs:
           path: output/
 
   validate-release:
-    if: ${{ github.event_name == 'push' && inputs.provenance }}
+    if: ${{ github.event_name == 'push' && inputs.provenance && !inputs.skip-validation && !contains(github.ref_name, 'skip-validation') }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -287,7 +294,7 @@ jobs:
             --tag-prefix "$INPUTS_TAG_PREFIX"
 
   package:
-    if: ${{ github.event_name == 'push' && inputs.provenance }}
+    if: ${{ github.event_name == 'push' && inputs.provenance && !cancelled() && !failure() }}
     needs: [validate-release]
     permissions:
       contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -178,14 +178,14 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
+        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart pub global activate --source path pkgs/firehose/
+        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
 
       - name: Fetch labels
@@ -215,7 +215,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          dart pub global run firehose \
+          firehose \
             --validate \
             "$FLUTTER_FLAG" \
             --ignore-packages "$INPUTS_IGNORE_PACKAGES" \
@@ -235,14 +235,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.number }}
-        run: dart pub global run firehose:comment create-or-update --issue "$ISSUE_NUMBER" --body-path output/comment.md
+        run: comment create-or-update --issue "$ISSUE_NUMBER" --body-path output/comment.md
 
       - name: Update comment
         if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments && (steps.comment-id.outputs.comment != '') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ steps.comment-id.outputs.comment }}
-        run: dart pub global run firehose:comment create-or-update --comment-id "$COMMENT_ID" --body-path output/comment.md
+        run: comment create-or-update --comment-id "$COMMENT_ID" --body-path output/comment.md
 
       - name: Save PR number
         if: ${{ !inputs.write-comments }}
@@ -286,14 +286,14 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
+        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart pub global activate --source path pkgs/firehose/
+        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
 
       - name: Validate package for release
@@ -306,7 +306,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          dart pub global run firehose \
+          firehose \
             --validate-release \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX"
@@ -340,14 +340,14 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
+        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart pub global activate --source path pkgs/firehose/
+        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
 
       - name: Package archive for provenance
@@ -360,7 +360,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          sudo -E unshare -n sudo -u $(whoami) -E env "PATH=$PATH" "HOME=$HOME" dart pub global run firehose \
+          sudo -E unshare -n sudo -u $(whoami) -E env "PATH=$PATH" "HOME=$HOME" firehose \
             --package-only \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX"
@@ -407,14 +407,14 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
+        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart pub global activate --source path pkgs/firehose/
+        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
 
       - name: Download package archive
@@ -455,7 +455,7 @@ jobs:
           else
             PROVENANCE_FLAG=""
           fi
-          dart pub global run firehose \
+          firehose \
             --publish \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -285,6 +285,29 @@ jobs:
         run: dart pub global activate --source path pkgs/firehose/
         if: ${{ inputs.local_debug }}
 
+      - name: Package archive for provenance
+        if: ${{ inputs.provenance }}
+        env:
+          INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
+          USE_FLUTTER: ${{ inputs.use-flutter }}
+        run: |
+          if [ "$USE_FLUTTER" = "true" ]; then
+            FLUTTER_FLAG="--use-flutter"
+          else
+            FLUTTER_FLAG="--no-use-flutter"
+          fi
+          dart pub global run firehose \
+            --package-only \
+            "$FLUTTER_FLAG" \
+            --tag-prefix "$INPUTS_TAG_PREFIX"
+
+      - name: Generate Build Provenance
+        if: ${{ inputs.provenance }}
+        id: attest
+        uses: actions/attest-build-provenance@c735d8856cf286b0337c76b92a6c11391754eb5e # v2.2.0
+        with:
+          subject-path: 'output/*.tar.gz'
+
       - name: Publish packages
         env:
           INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -178,6 +178,7 @@ jobs:
           GIT_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -185,11 +186,13 @@ jobs:
           FIREHOSE_REF: ${{ job.workflow_sha }}
         run: |
           dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install local firehose
         if: ${{ inputs.local_debug }}
         run: |
           dart install "firehose@{path: $PWD/pkgs/firehose}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Fetch labels
         id: fetch-labels
@@ -289,6 +292,7 @@ jobs:
           GIT_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -296,11 +300,13 @@ jobs:
           FIREHOSE_REF: ${{ job.workflow_sha }}
         run: |
           dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install local firehose
         if: ${{ inputs.local_debug }}
         run: |
           dart install "firehose@{path: $PWD/pkgs/firehose}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Validate package for release
         env:
@@ -346,6 +352,7 @@ jobs:
           GIT_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -353,11 +360,13 @@ jobs:
           FIREHOSE_REF: ${{ job.workflow_sha }}
         run: |
           dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install local firehose
         if: ${{ inputs.local_debug }}
         run: |
           dart install "firehose@{path: $PWD/pkgs/firehose}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Package archive for provenance
         env:
@@ -416,6 +425,7 @@ jobs:
           GIT_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
@@ -423,11 +433,13 @@ jobs:
           FIREHOSE_REF: ${{ job.workflow_sha }}
         run: |
           dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Install local firehose
         if: ${{ inputs.local_debug }}
         run: |
           dart install "firehose@{path: $PWD/pkgs/firehose}"
+          echo "$HOME/.local/state/Dart/install/bin" >> "$GITHUB_PATH"
 
       - name: Download package archive
         if: ${{ inputs.provenance || inputs.use-prebuilt-archive }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -148,6 +148,8 @@ jobs:
       pull-requests: write
 
     runs-on: ubuntu-latest
+    env:
+      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -180,8 +182,6 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -263,6 +263,8 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    env:
+      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -288,8 +290,6 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -317,6 +317,8 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    env:
+      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -342,8 +344,6 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -384,6 +384,8 @@ jobs:
       attestations: write
 
     runs-on: ubuntu-latest
+    env:
+      FIREHOSE_REF: ${{ job.workflow_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -409,8 +411,6 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -346,7 +346,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          sudo unshare -n sudo -u $(whoami) -E env "PATH=$PATH" dart pub global run firehose \
+          sudo unshare -n sudo -u $(whoami) -H env "PATH=$PATH" dart pub global run firehose \
             --package-only \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -186,7 +186,9 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
+        env:
+          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -292,7 +294,9 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
+        env:
+          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -344,7 +348,9 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
+        env:
+          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -409,7 +415,9 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
+        env:
+          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -415,6 +415,13 @@ jobs:
         with:
           subject-path: 'output/*.tar.gz'
 
+      - name: Upload attestation bundle
+        if: ${{ inputs.provenance }}
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        with:
+          name: attestation-bundle
+          path: ${{ steps.attest.outputs.bundle-path }}
+
       - name: Publish packages
         env:
           INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -187,7 +187,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -295,7 +295,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -349,7 +349,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -416,7 +416,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ inputs.firehose_ref }}
+          FIREHOSE_REF: ${{ job.workflow_sha || inputs.firehose_ref || 'main' }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -346,7 +346,7 @@ jobs:
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          unshare -r -n -- dart pub global run firehose \
+          sudo unshare -n sudo -u $(whoami) -E env "PATH=$PATH" dart pub global run firehose \
             --package-only \
             "$FLUTTER_FLAG" \
             --tag-prefix "$INPUTS_TAG_PREFIX"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -304,7 +304,7 @@ jobs:
       - name: Generate Build Provenance
         if: ${{ inputs.provenance }}
         id: attest
-        uses: actions/attest-build-provenance@c735d8856cf286b0337c76b92a6c11391754eb5e # v2.2.0
+        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
         with:
           subject-path: 'output/*.tar.gz'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -117,6 +117,12 @@ on:
         default: false
         required: false
         type: boolean
+      firehose_ref:
+        description: >-
+          The git ref to use when activating package:firehose from dart-lang/ecosystem.
+        default: "main"
+        required: false
+        type: string
       local_debug:
         description: Whether to use a local copy of package:firehose - only for debug
         default: false
@@ -166,11 +172,7 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: |
-          GIT_REF="${WORKFLOW_REF#*@}"
-          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -276,11 +278,7 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: |
-          GIT_REF="${WORKFLOW_REF#*@}"
-          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -332,11 +330,7 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: |
-          GIT_REF="${WORKFLOW_REF#*@}"
-          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -401,11 +395,7 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: |
-          GIT_REF="${WORKFLOW_REF#*@}"
-          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "${{ inputs.firehose_ref }}"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -235,8 +235,67 @@ jobs:
           name: output
           path: output/
 
+  validate-release:
+    if: ${{ github.event_name == 'push' && inputs.provenance }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-cache-
+
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        if: ${{ inputs.use-flutter }}
+        with:
+          channel: ${{ inputs.sdk }}
+          cache: true
+
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        if: ${{ !inputs.use-flutter }}
+        with:
+          sdk: ${{ inputs.sdk }}
+
+      - name: Install firehose (internal)
+        if: ${{ !inputs.local_debug && github.repository == 'dart-lang/ecosystem' }}
+        env:
+          GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
+          GIT_REF: ${{ github.head_ref || github.ref_name }}
+        run: dart pub global activate --source git "$GIT_URL" --git-path pkgs/firehose/ --git-ref "$GIT_REF"
+
+      - name: Install firehose (external)
+        if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
+        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+
+      - name: Install local firehose
+        run: dart pub global activate --source path pkgs/firehose/
+        if: ${{ inputs.local_debug }}
+
+      - name: Validate package for release
+        env:
+          INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
+          USE_FLUTTER: ${{ inputs.use-flutter }}
+        run: |
+          if [ "$USE_FLUTTER" = "true" ]; then
+            FLUTTER_FLAG="--use-flutter"
+          else
+            FLUTTER_FLAG="--no-use-flutter"
+          fi
+          dart pub global run firehose \
+            --validate-release \
+            "$FLUTTER_FLAG" \
+            --tag-prefix "$INPUTS_TAG_PREFIX"
+
   package:
     if: ${{ github.event_name == 'push' && inputs.provenance }}
+    needs: [validate-release]
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -304,7 +304,7 @@ jobs:
       - name: Generate Build Provenance
         if: ${{ inputs.provenance }}
         id: attest
-        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: 'output/*.tar.gz'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -166,7 +166,11 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          GIT_REF="${WORKFLOW_REF#*@}"
+          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -272,7 +276,11 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          GIT_REF="${WORKFLOW_REF#*@}"
+          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -324,7 +332,11 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          GIT_REF="${WORKFLOW_REF#*@}"
+          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/
@@ -389,7 +401,11 @@ jobs:
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
-        run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          GIT_REF="${WORKFLOW_REF#*@}"
+          dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$GIT_REF"
 
       - name: Install local firehose
         run: dart pub global activate --source path pkgs/firehose/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -117,6 +117,20 @@ on:
         default: false
         required: false
         type: boolean
+      use-prebuilt-archive:
+        description: >-
+          Whether to use a pre-built package archive uploaded by the caller workflow
+          (named by `package-archive-name` or defaulting to 'package-archive').
+          When true, skips the internal `validate-release` and `package` jobs.
+        default: false
+        required: false
+        type: boolean
+      package-archive-name:
+        description: >-
+          The name of the uploaded artifact containing the package archive(s).
+        default: "package-archive"
+        required: false
+        type: string
       firehose_ref:
         description: >-
           The git ref to use when activating package:firehose from dart-lang/ecosystem.
@@ -249,7 +263,7 @@ jobs:
           path: output/
 
   validate-release:
-    if: ${{ github.event_name == 'push' && inputs.provenance && !inputs.skip-validation && !contains(github.ref_name, 'skip-validation') }}
+    if: ${{ github.event_name == 'push' && inputs.provenance && !inputs.use-prebuilt-archive && !inputs.skip-validation && !contains(github.ref_name, 'skip-validation') }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -300,7 +314,7 @@ jobs:
             --tag-prefix "$INPUTS_TAG_PREFIX"
 
   package:
-    if: ${{ github.event_name == 'push' && inputs.provenance && !cancelled() && !failure() }}
+    if: ${{ github.event_name == 'push' && inputs.provenance && !inputs.use-prebuilt-archive && !cancelled() && !failure() }}
     needs: [validate-release]
     permissions:
       contents: read
@@ -402,21 +416,21 @@ jobs:
         if: ${{ inputs.local_debug }}
 
       - name: Download package archive
-        if: ${{ inputs.provenance }}
+        if: ${{ inputs.provenance || inputs.use-prebuilt-archive }}
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: package-archive
+          name: ${{ inputs.package-archive-name }}
           path: output/
 
       - name: Generate Build Provenance
-        if: ${{ inputs.provenance }}
+        if: ${{ inputs.provenance || inputs.use-prebuilt-archive }}
         id: attest
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: 'output/*.tar.gz'
 
       - name: Upload attestation bundle
-        if: ${{ inputs.provenance }}
+        if: ${{ inputs.provenance || inputs.use-prebuilt-archive }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: attestation-bundle
@@ -427,13 +441,14 @@ jobs:
           INPUTS_TAG_PREFIX: ${{ inputs.tag-prefix }}
           USE_FLUTTER: ${{ inputs.use-flutter }}
           PROVENANCE: ${{ inputs.provenance }}
+          USE_PREBUILT_ARCHIVE: ${{ inputs.use-prebuilt-archive }}
         run: |
           if [ "$USE_FLUTTER" = "true" ]; then
             FLUTTER_FLAG="--use-flutter"
           else
             FLUTTER_FLAG="--no-use-flutter"
           fi
-          if [ "$PROVENANCE" = "true" ]; then
+          if [ "$PROVENANCE" = "true" ] || [ "$USE_PREBUILT_ARCHIVE" = "true" ]; then
             PROVENANCE_FLAG="--provenance"
           else
             PROVENANCE_FLAG=""

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload folder with number and markdown
         if: ${{ !inputs.write-comments }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: output
           path: output/
@@ -339,7 +339,7 @@ jobs:
             --tag-prefix "$INPUTS_TAG_PREFIX"
 
       - name: Upload package archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.0.0
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: package-archive
           path: output/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -176,17 +176,20 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
           FIREHOSE_REF: ${{ job.workflow_sha }}
-        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
+        run: |
+          dart install "firehose@{path: $PWD/pkgs/firehose}"
 
       - name: Fetch labels
         id: fetch-labels
@@ -284,17 +287,20 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
           FIREHOSE_REF: ${{ job.workflow_sha }}
-        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
+        run: |
+          dart install "firehose@{path: $PWD/pkgs/firehose}"
 
       - name: Validate package for release
         env:
@@ -338,17 +344,20 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
           FIREHOSE_REF: ${{ job.workflow_sha }}
-        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
+        run: |
+          dart install "firehose@{path: $PWD/pkgs/firehose}"
 
       - name: Package archive for provenance
         env:
@@ -405,17 +414,20 @@ jobs:
         env:
           GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/dart-lang/ecosystem' }}
           GIT_REF: ${{ github.head_ref || github.ref_name }}
-        run: dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: '$GIT_URL', path: pkgs/firehose, ref: '$GIT_REF'}}"
 
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
           FIREHOSE_REF: ${{ job.workflow_sha }}
-        run: dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
+        run: |
+          dart install "firehose@{git: {url: https://github.com/dart-lang/ecosystem, path: pkgs/firehose, ref: '$FIREHOSE_REF'}}"
 
       - name: Install local firehose
-        run: dart install "firehose@{path: $PWD/pkgs/firehose}"
         if: ${{ inputs.local_debug }}
+        run: |
+          dart install "firehose@{path: $PWD/pkgs/firehose}"
 
       - name: Download package archive
         if: ${{ inputs.provenance || inputs.use-prebuilt-archive }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -181,7 +181,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -289,7 +289,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -343,7 +343,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose
@@ -410,7 +410,7 @@ jobs:
       - name: Install firehose (external)
         if: ${{ !inputs.local_debug && github.repository != 'dart-lang/ecosystem' }}
         env:
-          FIREHOSE_REF: ${{ job.workflow_sha || 'main' }}
+          FIREHOSE_REF: ${{ job.workflow_sha }}
         run: dart pub global activate --source git https://github.com/dart-lang/ecosystem --git-path pkgs/firehose/ --git-ref "$FIREHOSE_REF"
 
       - name: Install local firehose

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -24,3 +24,4 @@ jobs:
       id-token: write
       pull-requests: write
       attestations: write
+      contents: read

--- a/.github/workflows/publish_internal.yaml
+++ b/.github/workflows/publish_internal.yaml
@@ -23,3 +23,4 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
+      attestations: write

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.13.2-wip
 
+- Add `--provenance` option to `firehose` and `provenance` input to `publish.yaml` to support package provenance signing.
 - Add `--tag-prefix` option to `firehose` and `tag-prefix` input to `publish.yaml` to allow configuring the release tag prefix (defaults to `'v'`).
 - Run `pub get` before `dart format` in `groundskeeper`.
 - Add `groundskeeper` executable to format and fix packages.

--- a/pkgs/firehose/bin/firehose.dart
+++ b/pkgs/firehose/bin/firehose.dart
@@ -13,6 +13,7 @@ const validateFlag = 'validate';
 const publishFlag = 'publish';
 const useFlutterFlag = 'use-flutter';
 const tagPrefixOption = 'tag-prefix';
+const provenanceFlag = 'provenance';
 
 void main(List<String> arguments) async {
   final argParser = _createArgs();
@@ -28,6 +29,7 @@ void main(List<String> arguments) async {
     final publish = argResults[publishFlag] as bool;
     final useFlutter = argResults[useFlutterFlag] as bool;
     final tagPrefix = argResults[tagPrefixOption] as String;
+    final provenance = argResults[provenanceFlag] as bool;
     final ignoredPackages = (argResults['ignore-packages'] as List<String>)
         .where((pattern) => pattern.isNotEmpty)
         .map((pattern) => Glob(pattern, recursive: true))
@@ -54,6 +56,7 @@ void main(List<String> arguments) async {
       useFlutter,
       ignoredPackages,
       tagPrefix: tagPrefix,
+      provenance: provenance,
     );
 
     if (validate) {
@@ -106,6 +109,11 @@ ArgParser _createArgs() => ArgParser()
     tagPrefixOption,
     defaultsTo: 'v',
     help: 'The tag prefix to expect and generate (e.g. "v" or "").',
+  )
+  ..addFlag(
+    provenanceFlag,
+    negatable: false,
+    help: 'Whether to sign packages with build provenance before publishing.',
   )
   ..addMultiOption(
     'ignore-packages',

--- a/pkgs/firehose/bin/firehose.dart
+++ b/pkgs/firehose/bin/firehose.dart
@@ -11,6 +11,7 @@ import 'package:glob/glob.dart';
 const helpFlag = 'help';
 const validateFlag = 'validate';
 const publishFlag = 'publish';
+const packageOnlyFlag = 'package-only';
 const useFlutterFlag = 'use-flutter';
 const tagPrefixOption = 'tag-prefix';
 const provenanceFlag = 'provenance';
@@ -27,6 +28,7 @@ void main(List<String> arguments) async {
 
     final validate = argResults[validateFlag] as bool;
     final publish = argResults[publishFlag] as bool;
+    final packageOnly = argResults[packageOnlyFlag] as bool;
     final useFlutter = argResults[useFlutterFlag] as bool;
     final tagPrefix = argResults[tagPrefixOption] as String;
     final provenance = argResults[provenanceFlag] as bool;
@@ -35,18 +37,21 @@ void main(List<String> arguments) async {
         .map((pattern) => Glob(pattern, recursive: true))
         .toList();
 
-    if (!validate && !publish) {
+    if (!validate && !publish && !packageOnly) {
       _usage(argParser,
-          error: 'Error: one of --validate or --publish must be specified.');
+          error:
+              'Error: one of --validate, --publish, or --package-only must be '
+              'specified.');
       exitCode = 1;
       return;
     }
 
     final github = GithubApi();
-    if (publish && !github.inGithubContext) {
+    if ((publish || packageOnly) && !github.inGithubContext) {
       _usage(argParser,
-          error: 'Error: --publish can only be executed from within a GitHub '
-              'action.');
+          error:
+              'Error: --publish and --package-only can only be executed from '
+              'within a GitHub action.');
       exitCode = 1;
       return;
     }
@@ -63,6 +68,8 @@ void main(List<String> arguments) async {
       await firehose.validate();
     } else if (publish) {
       await firehose.publish();
+    } else if (packageOnly) {
+      await firehose.packageOnly();
     }
   } on ArgParserException catch (e) {
     _usage(argParser, error: e.message);
@@ -99,6 +106,11 @@ ArgParser _createArgs() => ArgParser()
     publishFlag,
     negatable: false,
     help: 'Publish any changed packages.',
+  )
+  ..addFlag(
+    packageOnlyFlag,
+    negatable: false,
+    help: 'Package the archive for the release tag without publishing.',
   )
   ..addFlag(
     useFlutterFlag,

--- a/pkgs/firehose/bin/firehose.dart
+++ b/pkgs/firehose/bin/firehose.dart
@@ -10,6 +10,7 @@ import 'package:glob/glob.dart';
 
 const helpFlag = 'help';
 const validateFlag = 'validate';
+const validateReleaseFlag = 'validate-release';
 const publishFlag = 'publish';
 const packageOnlyFlag = 'package-only';
 const useFlutterFlag = 'use-flutter';
@@ -27,6 +28,7 @@ void main(List<String> arguments) async {
     }
 
     final validate = argResults[validateFlag] as bool;
+    final validateRelease = argResults[validateReleaseFlag] as bool;
     final publish = argResults[publishFlag] as bool;
     final packageOnly = argResults[packageOnlyFlag] as bool;
     final useFlutter = argResults[useFlutterFlag] as bool;
@@ -37,21 +39,20 @@ void main(List<String> arguments) async {
         .map((pattern) => Glob(pattern, recursive: true))
         .toList();
 
-    if (!validate && !publish && !packageOnly) {
+    if (!validate && !validateRelease && !publish && !packageOnly) {
       _usage(argParser,
-          error:
-              'Error: one of --validate, --publish, or --package-only must be '
-              'specified.');
+          error: 'Error: one of --validate, --validate-release, --publish, or '
+              '--package-only must be specified.');
       exitCode = 1;
       return;
     }
 
     final github = GithubApi();
-    if ((publish || packageOnly) && !github.inGithubContext) {
+    if ((validateRelease || publish || packageOnly) &&
+        !github.inGithubContext) {
       _usage(argParser,
-          error:
-              'Error: --publish and --package-only can only be executed from '
-              'within a GitHub action.');
+          error: 'Error: --validate-release, --publish, and --package-only can '
+              'only be executed from within a GitHub action.');
       exitCode = 1;
       return;
     }
@@ -66,6 +67,8 @@ void main(List<String> arguments) async {
 
     if (validate) {
       await firehose.validate();
+    } else if (validateRelease) {
+      await firehose.validateRelease();
     } else if (publish) {
       await firehose.publish();
     } else if (packageOnly) {
@@ -101,6 +104,11 @@ ArgParser _createArgs() => ArgParser()
     negatable: false,
     help: 'Validate packages and indicate whether --publish would publish '
         'anything.',
+  )
+  ..addFlag(
+    validateReleaseFlag,
+    negatable: false,
+    help: 'Validate the release package with pub publish --dry-run.',
   )
   ..addFlag(
     publishFlag,

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -224,6 +224,18 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     );
 
     final command = useFlutter ? 'flutter' : 'dart';
+    print('Validating ${package.name} with dry-run before packaging...');
+    final dryRunResult = await runCommand(
+      command,
+      args: ['pub', 'publish', '--dry-run'],
+      cwd: package.directory,
+    );
+    if (dryRunResult.code != 0) {
+      exitCode = dryRunResult.code;
+      return false;
+    }
+    print('');
+
     print(
       'Creating package archive at ${archiveFile.path} '
       'for provenance signing...',

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -197,6 +197,54 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     return results;
   }
 
+  /// Package the archive for the targeted package without publishing.
+  Future packageOnly() async {
+    final success = await _packageOnly();
+    if (!success && exitCode == 0) {
+      exitCode = 1;
+    }
+  }
+
+  Future<bool> _packageOnly() async {
+    final package = _findPackageToPublish();
+    if (package == null) return false;
+
+    print('Packaging ${'package:${package.name}'}');
+    print('');
+
+    await runCommand('dart', args: ['pub', 'get'], cwd: package.directory);
+    print('');
+
+    final outputDir = Directory('output');
+    if (!outputDir.existsSync()) {
+      await outputDir.create(recursive: true);
+    }
+    final archiveFile = File(
+      '${outputDir.path}/${package.name}-${package.pubspec.version}.tar.gz',
+    );
+
+    final command = useFlutter ? 'flutter' : 'dart';
+    print(
+      'Creating package archive at ${archiveFile.path} '
+      'for provenance signing...',
+    );
+    final result = await runCommand(
+      command,
+      args: [
+        'pub',
+        'publish',
+        '--to-archive=${archiveFile.path}',
+      ],
+      cwd: package.directory,
+    );
+    if (result.code != 0) {
+      exitCode = result.code;
+      return false;
+    }
+    print('Package archive created at ${archiveFile.path}');
+    return true;
+  }
+
   /// Publish the indicated package in the repository.
   ///
   /// This is intended to be run on a github workflow in response to a git tag.
@@ -213,18 +261,58 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
   }
 
   Future<bool> _publish() async {
+    final package = _findPackageToPublish();
+    if (package == null) return false;
+
+    print('');
+    print('Publishing ${'package:${package.name}'}');
+    print('');
+
+    await runCommand('dart', args: ['pub', 'get'], cwd: package.directory);
+    print('');
+
+    final archiveFile = File(
+      'output/${package.name}-${package.pubspec.version}.tar.gz',
+    );
+    if (provenance && archiveFile.existsSync()) {
+      print('Publishing from prepared archive: ${archiveFile.path}');
+      final command = useFlutter ? 'flutter' : 'dart';
+      final result = await runCommand(
+        command,
+        args: [
+          'pub',
+          'publish',
+          '--from-archive=${archiveFile.path}',
+          '--force',
+        ],
+        cwd: package.directory,
+      );
+      if (result.code != 0) {
+        exitCode = result.code;
+      }
+      return result.code == 0;
+    }
+
+    final result = await _runPublish(package, dryRun: false, force: true);
+    if (result.code != 0) {
+      exitCode = result.code;
+    }
+    return result.code == 0;
+  }
+
+  Package? _findPackageToPublish() {
     final github = GithubApi();
 
-    if (!expectEnv(github.refName, 'GITHUB_REF_NAME')) return false;
+    if (!expectEnv(github.refName, 'GITHUB_REF_NAME')) return null;
 
     // Validate the git tag.
     final tag = Tag(github.refName!, prefix: tagPrefix);
     if (!tag.valid) {
       stderr.writeln("Git tag not in expected format: '$tag'");
-      return false;
+      return null;
     }
 
-    print("Publishing '$tag'");
+    print("Targeting git tag '$tag'");
     print('');
 
     final repo = Repository();
@@ -241,25 +329,21 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     if (repo.isSinglePackageRepo) {
       if (packages.isEmpty) {
         stderr.writeln('No publishable package found.');
-        return false;
+        return null;
       }
       package = packages.first;
     } else {
       final name = tag.package;
       if (name == null) {
         stderr.writeln("Tag does not include package name ('$tag').");
-        return false;
+        return null;
       }
       if (!packages.any((p) => p.name == name)) {
         stderr.writeln("Tag does not match a repo package ('$tag').");
-        return false;
+        return null;
       }
       package = packages.firstWhere((p) => p.name == name);
     }
-
-    print('');
-    print('Publishing ${'package:${package.name}'}');
-    print('');
 
     print('pubspec:');
     final pubspecVersion = package.pubspec.version?.toString();
@@ -273,7 +357,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       stderr.writeln(
         "Pubspec version ($pubspecVersion) and git tag ($tag) don't agree.",
       );
-      return false;
+      return null;
     }
 
     if (pubspecVersion != changelogVersion) {
@@ -281,17 +365,10 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
         'Pubspec version ($pubspecVersion) and changelog version '
         "($changelogVersion) don't agree.",
       );
-      return false;
+      return null;
     }
 
-    await runCommand('dart', args: ['pub', 'get'], cwd: package.directory);
-    print('');
-
-    final result = await _runPublish(package, dryRun: false, force: true);
-    if (result.code != 0) {
-      exitCode = result.code;
-    }
-    return result.code == 0;
+    return package;
   }
 
   Future<CommandResult> _runPublish(
@@ -304,46 +381,6 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       command = 'flutter';
     } else {
       command = 'dart';
-    }
-
-    if (provenance && !dryRun) {
-      final tempDir = await Directory.systemTemp.createTemp('firehose_pkg_');
-      try {
-        final archiveFile = File(
-          '${tempDir.path}/${package.name}-${package.pubspec.version}.tar.gz',
-        );
-        print(
-          'Packaging ${package.name} archive to ${archiveFile.path} '
-          'for provenance signing...',
-        );
-        final archiveResult = await runCommand(
-          command,
-          args: [
-            'pub',
-            'publish',
-            '--to-archive=${archiveFile.path}',
-          ],
-          cwd: package.directory,
-        );
-        if (archiveResult.code != 0) {
-          return archiveResult;
-        }
-
-        print('Package archive created at ${archiveFile.path}');
-
-        return await runCommand(
-          command,
-          args: [
-            'pub',
-            'publish',
-            '--from-archive=${archiveFile.path}',
-            if (force) '--force',
-          ],
-          cwd: package.directory,
-        );
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
     }
 
     return await runCommand(

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -246,6 +246,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
         'pub',
         'publish',
         '--to-archive=${archiveFile.path}',
+        '--skip-validation',
       ],
       cwd: package.directory,
     );

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -261,16 +261,26 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       'Creating package archive at ${archiveFile.path} '
       'for provenance signing...',
     );
-    final result = await runCommand(
-      command,
-      args: [
-        'pub',
-        'publish',
-        '--to-archive=${archiveFile.path}',
-        '--skip-validation',
-      ],
-      cwd: package.directory,
-    );
+    final publishArgs = [
+      'pub',
+      'publish',
+      '--to-archive=${archiveFile.path}',
+      '--skip-validation',
+    ];
+    final CommandResult result;
+    if (Platform.isLinux) {
+      result = await runCommand(
+        'unshare',
+        args: ['-r', '-n', '--', command, ...publishArgs],
+        cwd: package.directory,
+      );
+    } else {
+      result = await runCommand(
+        command,
+        args: publishArgs,
+        cwd: package.directory,
+      );
+    }
     if (result.code != 0) {
       exitCode = result.code;
       return false;

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -245,9 +245,6 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     print('Packaging ${'package:${package.name}'}');
     print('');
 
-    await runCommand('dart', args: ['pub', 'get'], cwd: package.directory);
-    print('');
-
     final outputDir = Directory('output');
     if (!outputDir.existsSync()) {
       await outputDir.create(recursive: true);
@@ -261,26 +258,16 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       'Creating package archive at ${archiveFile.path} '
       'for provenance signing...',
     );
-    final publishArgs = [
-      'pub',
-      'publish',
-      '--to-archive=${archiveFile.path}',
-      '--skip-validation',
-    ];
-    final CommandResult result;
-    if (Platform.isLinux) {
-      result = await runCommand(
-        'unshare',
-        args: ['-r', '-n', '--', command, ...publishArgs],
-        cwd: package.directory,
-      );
-    } else {
-      result = await runCommand(
-        command,
-        args: publishArgs,
-        cwd: package.directory,
-      );
-    }
+    final result = await runCommand(
+      command,
+      args: [
+        'pub',
+        'publish',
+        '--to-archive=${archiveFile.path}',
+        '--skip-validation',
+      ],
+      cwd: package.directory,
+    );
     if (result.code != 0) {
       exitCode = result.code;
       return false;

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -32,12 +32,14 @@ class Firehose {
   final bool useFlutter;
   final List<Glob> ignoredPackages;
   final String tagPrefix;
+  final bool provenance;
 
   Firehose(
     this.directory,
     this.useFlutter,
     this.ignoredPackages, {
     this.tagPrefix = 'v',
+    this.provenance = false,
   });
 
   /// Validate the packages in the repository.
@@ -303,6 +305,47 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     } else {
       command = 'dart';
     }
+
+    if (provenance && !dryRun) {
+      final tempDir = await Directory.systemTemp.createTemp('firehose_pkg_');
+      try {
+        final archiveFile = File(
+          '${tempDir.path}/${package.name}-${package.pubspec.version}.tar.gz',
+        );
+        print(
+          'Packaging ${package.name} archive to ${archiveFile.path} '
+          'for provenance signing...',
+        );
+        final archiveResult = await runCommand(
+          command,
+          args: [
+            'pub',
+            'publish',
+            '--to-archive=${archiveFile.path}',
+          ],
+          cwd: package.directory,
+        );
+        if (archiveResult.code != 0) {
+          return archiveResult;
+        }
+
+        print('Package archive created at ${archiveFile.path}');
+
+        return await runCommand(
+          command,
+          args: [
+            'pub',
+            'publish',
+            '--from-archive=${archiveFile.path}',
+            if (force) '--force',
+          ],
+          cwd: package.directory,
+        );
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    }
+
     return await runCommand(
       command,
       args: ['pub', 'publish', if (dryRun) '--dry-run', if (force) '--force'],

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -197,6 +197,39 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     return results;
   }
 
+  /// Validate the targeted package for release without publishing or packaging.
+  Future validateRelease() async {
+    final success = await _validateRelease();
+    if (!success && exitCode == 0) {
+      exitCode = 1;
+    }
+  }
+
+  Future<bool> _validateRelease() async {
+    final package = _findPackageToPublish();
+    if (package == null) return false;
+
+    print('Validating ${'package:${package.name}'} with pub publish --dry-run');
+    print('');
+
+    await runCommand('dart', args: ['pub', 'get'], cwd: package.directory);
+    print('');
+
+    final command = useFlutter ? 'flutter' : 'dart';
+    final dryRunResult = await runCommand(
+      command,
+      args: ['pub', 'publish', '--dry-run'],
+      cwd: package.directory,
+    );
+    if (dryRunResult.code != 0) {
+      exitCode = dryRunResult.code;
+      return false;
+    }
+    print('');
+    print('Package validation succeeded for ${package.name}.');
+    return true;
+  }
+
   /// Package the archive for the targeted package without publishing.
   Future packageOnly() async {
     final success = await _packageOnly();
@@ -224,18 +257,6 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     );
 
     final command = useFlutter ? 'flutter' : 'dart';
-    print('Validating ${package.name} with dry-run before packaging...');
-    final dryRunResult = await runCommand(
-      command,
-      args: ['pub', 'publish', '--dry-run'],
-      cwd: package.directory,
-    );
-    if (dryRunResult.code != 0) {
-      exitCode = dryRunResult.code;
-      return false;
-    }
-    print('');
-
     print(
       'Creating package archive at ${archiveFile.path} '
       'for provenance signing...',

--- a/pkgs/firehose/test/repo_test.dart
+++ b/pkgs/firehose/test/repo_test.dart
@@ -8,6 +8,7 @@ library;
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:firehose/firehose.dart';
 import 'package:firehose/src/github.dart';
 import 'package:firehose/src/repo.dart';
 import 'package:github/github.dart' show RepositorySlug;
@@ -118,6 +119,18 @@ void main() {
             isA<Package>().having((p) => p.name, 'name', 'pkg_1'),
             isA<Package>().having((p) => p.name, 'name', 'pkg_2'),
           ]));
+    });
+  });
+
+  group('firehose configuration', () {
+    test('default provenance is false', () {
+      final firehose = Firehose(Directory.current, false, []);
+      expect(firehose.provenance, isFalse);
+    });
+
+    test('custom provenance', () {
+      final firehose = Firehose(Directory.current, false, [], provenance: true);
+      expect(firehose.provenance, isTrue);
     });
   });
 }

--- a/pkgs/firehose/test/repo_test.dart
+++ b/pkgs/firehose/test/repo_test.dart
@@ -9,8 +9,6 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:firehose/firehose.dart';
-import 'package:firehose/src/github.dart';
-import 'package:firehose/src/repo.dart';
 import 'package:github/github.dart' show RepositorySlug;
 import 'package:test/test.dart';
 


### PR DESCRIPTION
Just an idea re https://github.com/dart-lang/pub-dev/issues/5750 . The pub client currently doesn't support uploading the attestation, so this currently goes nowhere, but if `dart pub publish` would support that it would work immediately.

Also has a follow up https://github.com/dart-lang/ecosystem/pull/442 for the SBOM.

what do you think? @athomas @jonasfj @sigurdm 


## Description

This PR adds initial support for package provenance signing to the reusable publish workflow and `firehose` bot, hidden behind an experimental `--provenance` / `provenance: true` flag.

### Changes:
- **`.github/workflows/publish.yaml`**:
  - Added `provenance` input (boolean, defaults to `false`).
  - Added `attestations: write` permission to the `publish` job.
  - Added package archive step (`firehose --package-only`).
  - Added artifact attestation step using `actions/attest@v4`.
  - Forwarded the `--provenance` flag to `firehose --publish`.
- **`pkgs/firehose`**:
  - Added `--package-only` and `--provenance` flags to CLI arguments and `Firehose` constructor.
  - When `--package-only` is invoked, packages the `.tar.gz` archive to `output/<package>-<version>.tar.gz` using `dart pub publish --to-archive=...`.
  - When `--provenance` is active during publishing, publishes from the prepared archive via `dart pub publish --from-archive=...`.
  - Added unit tests for `Firehose(provenance: ...)`.
  - Updated `CHANGELOG.md`.

Part of the ongoing package signing and provenance verification initiative for pub.dev.