### PR TITLE
[publish] Generate and attest SBOM using Anchore Syft

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -448,6 +448,24 @@ jobs:
           name: ${{ inputs.package-archive-name }}
           path: output/
 
+      - name: Generate SBOM with Syft
+        if: ${{ inputs.provenance }}
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: output/sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate SBOM Attestation
+        if: ${{ inputs.provenance }}
+        id: attest-sbom
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: 'output/*.tar.gz'
+          sbom-path: 'output/sbom.spdx.json'
+
       - name: Generate Build Provenance
         if: ${{ inputs.provenance || inputs.use-prebuilt-archive }}
         id: attest


### PR DESCRIPTION
## Description

Follow-up to #441: This PR integrates [Anchore Syft](https://github.com/anchore/syft) via `anchore/sbom-action` to automatically generate an **SPDX 2.3 JSON Software Bill of Materials (SBOM)** from the published package dependency tree, and signs/records an **SBOM Attestation** with Sigstore using `actions/attest@v4`.

### Changes:
- **`.github/workflows/publish.yaml`**:
  - Added `Generate SBOM with Syft` step using `anchore/sbom-action@v0.24.0` to generate `output/sbom.spdx.json`.
  - Added `Generate SBOM Attestation` step using `actions/attest@v4` with `sbom-path: 'output/sbom.spdx.json'`.

Part of the ongoing package signing and supply chain security initiative for `pub.dev`.