### PR TITLE
Support use-flutter option in groundskeeper workflow

### DIFF
--- a/.github/workflows/groundskeeper.yml
+++ b/.github/workflows/groundskeeper.yml
@@ -63,17 +63,21 @@ jobs:
         with:
           client-id: ${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ECOSYSTEM_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout caller repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
 
       - name: Checkout ecosystem (for tidy script)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: dart-lang/ecosystem
           path: .github/ecosystem-helper
+          persist-credentials: false
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
@@ -86,10 +90,13 @@ jobs:
 
       - name: Run Tidy Script
         working-directory: ${{ inputs.directory }}
+        env:
+          RUN_FORMAT: ${{ inputs.run-format }}
+          RUN_FIX: ${{ inputs.run-fix }}
         run: |
           dart $GITHUB_WORKSPACE/.github/ecosystem-helper/pkgs/firehose/bin/groundskeeper.dart \
-            --format=${{ inputs.run-format }} \
-            --fix=${{ inputs.run-fix }}
+            --format="$RUN_FORMAT" \
+            --fix="$RUN_FIX"
 
       - name: Check for changes
         id: check_changes
@@ -104,9 +111,12 @@ jobs:
       - name: Update changelog
         if: ${{ inputs.update-changelog && steps.check_changes.outputs.changed == 'true' }}
         working-directory: .github/ecosystem-helper/pkgs/repo_manage
+        env:
+          DIRECTORY: ${{ inputs.directory }}
+          CHANGELOG_MESSAGE: ${{ inputs.changelog-message }}
         run: |
           dart pub get
-          dart run bin/report.dart changelog --changelog "../../../../${{ inputs.directory }}/CHANGELOG.md" "${{ inputs.changelog-message }}"
+          dart run bin/report.dart changelog --changelog "../../../../$DIRECTORY/CHANGELOG.md" "$CHANGELOG_MESSAGE"
 
       - name: Clean up helper
         run: rm -rf .github/ecosystem-helper

--- a/.github/workflows/groundskeeper.yml
+++ b/.github/workflows/groundskeeper.yml
@@ -5,10 +5,15 @@ on:
   workflow_call:
     inputs:
       sdk:
-        description: 'Flutter SDK channel'
+        description: 'Dart SDK version or Flutter channel'
         required: false
         type: string
         default: 'dev'
+      use-flutter:
+        description: 'Whether to use Flutter for this package'
+        required: false
+        type: boolean
+        default: false
       directory:
         description: 'The directory to tidy'
         required: false
@@ -80,9 +85,15 @@ jobs:
           persist-credentials: false
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        if: ${{ inputs.use-flutter }}
         with:
           channel: ${{ inputs.sdk }}
           cache: true
+
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        if: ${{ !inputs.use-flutter }}
+        with:
+          sdk: ${{ inputs.sdk }}
 
       - name: Resolve dependencies for firehose
         working-directory: .github/ecosystem-helper/pkgs/firehose

--- a/.github/workflows/groundskeeper.yml
+++ b/.github/workflows/groundskeeper.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       sdk:
-        description: 'Dart SDK version'
+        description: 'Flutter SDK channel'
         required: false
         type: string
         default: 'dev'
@@ -75,9 +75,10 @@ jobs:
           repository: dart-lang/ecosystem
           path: .github/ecosystem-helper
 
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          sdk: ${{ inputs.sdk }}
+          channel: ${{ inputs.sdk }}
+          cache: true
 
       - name: Resolve dependencies for firehose
         working-directory: .github/ecosystem-helper/pkgs/firehose

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.13.2-wip
 
-- Use Flutter `dev` channel in `groundskeeper` workflow to support Flutter packages.
+- Support `use-flutter` option in `groundskeeper` workflow to allow tidying Flutter packages.
 - Add `--tag-prefix` option to `firehose` and `tag-prefix` input to `publish.yaml` to allow configuring the release tag prefix (defaults to `'v'`).
 - Run `pub get` before `dart format` in `groundskeeper`.
 - Add `groundskeeper` executable to format and fix packages.

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.13.2-wip
 
+- Use Flutter `dev` channel in `groundskeeper` workflow to support Flutter packages.
 - Add `--tag-prefix` option to `firehose` and `tag-prefix` input to `publish.yaml` to allow configuring the release tag prefix (defaults to `'v'`).
 - Run `pub get` before `dart format` in `groundskeeper`.
 - Add `groundskeeper` executable to format and fix packages.


### PR DESCRIPTION
Adds a `use-flutter` option (defaulting to `false`) to `groundskeeper.yml`.

When `use-flutter` is `true`:
- Uses `subosito/flutter-action` with the specified channel (`sdk`, defaulting to `dev`) so that Flutter and Dart are available on PATH for Flutter packages (such as `cronet_http` or `ok_http`).

When `use-flutter` is `false` (default):
- Uses `dart-lang/setup-dart` with the specified SDK version / channel (defaulting to `dev`), keeping setup fast and lightweight for pure Dart packages.

Addresses feedback from https://github.com/dart-lang/http/pull/1959.