### PR TITLE
Condense firehose package publishing table in PR validation

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.13.2-wip
 
+- Condense PR package publishing table to show only packages affected by the PR,
+  packages ready to publish, and errors, summarizing unaffected WIP and published
+  packages.
 - Add `--tag-prefix` option to `firehose` and `tag-prefix` input to `publish.yaml` to allow configuring the release tag prefix (defaults to `'v'`).
 - Run `pub get` before `dart format` in `groundskeeper`.
 - Add `groundskeeper` executable to format and fix packages.

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -366,8 +366,11 @@ class VerificationResults {
 
         tagColumn = ' | $tag';
       }
+      final pkgName = r.isAffected
+          ? '**package:${r.package.name}** ⭐'
+          : 'package:${r.package.name}';
       buffer.writeln(
-        '| package:${r.package.name} | ${r.package.version} | '
+        '| $pkgName | ${r.package.version} | '
         '$sev${r.message}$tagColumn |',
       );
     }

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -114,16 +114,15 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       github.listFilesForPR(directory, ignoredPackages),
       logError: print,
     );
+    final relevantFiles = filesInPR?.where((f) => f.status.isRelevant).toList();
 
     final pub = Pub();
 
     final results = VerificationResults();
 
     for (final package in packages) {
-      final isAffected = filesInPR == null ||
-          filesInPR
-              .where((f) => f.status.isRelevant)
-              .any((f) => f.isInPackage(package));
+      final isAffected = relevantFiles == null ||
+          relevantFiles.any((f) => f.isInPackage(package));
 
       final repoTag = repo.calculateRepoTag(package, tagPrefix: tagPrefix);
 
@@ -163,7 +162,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       if (await pub.hasPublishedVersion(package.name, pubspecVersion)) {
         final result = Result.info(
           package,
-          'already published at pub.dev',
+          Result.alreadyPublishedMessage,
           isAffected: isAffected,
         );
         print(result);
@@ -171,7 +170,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       } else if (package.pubspec.version!.wip) {
         final result = Result.info(
           package,
-          'WIP (no publish necessary)',
+          Result.wipMessage,
           isAffected: isAffected,
         );
         print(result);
@@ -377,8 +376,8 @@ class VerificationResults {
 
     final hidden = hiddenResults.toList();
     final alreadyPublishedCount =
-        hidden.where((r) => r.message.startsWith('already published')).length;
-    final wipCount = hidden.where((r) => r.message.startsWith('WIP')).length;
+        hidden.where((r) => r.message == Result.alreadyPublishedMessage).length;
+    final wipCount = hidden.where((r) => r.message == Result.wipMessage).length;
 
     final summaryLines = <String>[];
     if (alreadyPublishedCount > 0) {
@@ -400,6 +399,9 @@ class VerificationResults {
 }
 
 class Result {
+  static const String alreadyPublishedMessage = 'already published at pub.dev';
+  static const String wipMessage = 'WIP (no publish necessary)';
+
   final Severity severity;
   final Package package;
   final String message;

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -382,10 +382,10 @@ class VerificationResults {
 
     final summaryLines = <String>[];
     if (alreadyPublishedCount > 0) {
-      summaryLines.add('$alreadyPublishedCount already published.');
+      summaryLines.add('* $alreadyPublishedCount already published.');
     }
     if (wipCount > 0) {
-      summaryLines.add('$wipCount WIP (no publish necessary).');
+      summaryLines.add('* $wipCount WIP (no publish necessary).');
     }
 
     if (summaryLines.isNotEmpty) {

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -110,11 +110,21 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
     final repo = Repository(directory);
     final packages = repo.locatePackages(ignore: ignoredPackages);
 
+    final filesInPR = await allowFailure(
+      github.listFilesForPR(directory, ignoredPackages),
+      logError: print,
+    );
+
     final pub = Pub();
 
     final results = VerificationResults();
 
     for (final package in packages) {
+      final isAffected = filesInPR == null ||
+          filesInPR
+              .where((f) => f.status.isRelevant)
+              .any((f) => f.isInPackage(package));
+
       final repoTag = repo.calculateRepoTag(package, tagPrefix: tagPrefix);
 
       print('');
@@ -126,6 +136,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
         final result = Result.fail(
           package,
           "no version specified (perhaps you need a' publish_to: none' entry?)",
+          isAffected: isAffected,
         );
         print(result);
         results.addResult(result);
@@ -142,6 +153,7 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
           package,
           'pubspec version ($pubspecVersion) and changelog ($changelogVersion) '
           "don't agree",
+          isAffected: isAffected,
         );
         print(result);
         results.addResult(result);
@@ -149,11 +161,19 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       }
 
       if (await pub.hasPublishedVersion(package.name, pubspecVersion)) {
-        final result = Result.info(package, 'already published at pub.dev');
+        final result = Result.info(
+          package,
+          'already published at pub.dev',
+          isAffected: isAffected,
+        );
         print(result);
         results.addResult(result);
       } else if (package.pubspec.version!.wip) {
-        final result = Result.info(package, 'WIP (no publish necessary)');
+        final result = Result.info(
+          package,
+          'WIP (no publish necessary)',
+          isAffected: isAffected,
+        );
         print(result);
         results.addResult(result);
       } else {
@@ -172,17 +192,20 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
               'pub publish dry-run failed; add the `$_ignoreWarningsLabel` '
               'label to ignore';
           github.notice(message: message);
-          results.addResult(Result.fail(package, message));
+          results.addResult(
+            Result.fail(package, message, isAffected: isAffected),
+          );
         } else {
           final result = Result.success(
             package,
             '**ready to publish**',
-            repoTag,
-            repo.calculateReleaseUri(
+            gitTag: repoTag,
+            publishReleaseUri: repo.calculateReleaseUri(
               package,
               github,
               tagPrefix: tagPrefix,
             ),
+            isAffected: isAffected,
           );
           print(result);
           results.addResult(result);
@@ -323,21 +346,54 @@ class VerificationResults {
 
   bool get hasError => results.any((r) => r.severity == Severity.error);
 
-  String describeAsMarkdown({bool withTag = true}) => results.map((r) {
-        final sev = r.severity == Severity.error ? '(error) ' : '';
-        var tagColumn = '';
-        if (withTag) {
-          var tag = r.gitTag == null ? '' : '`${r.gitTag}`';
-          final publishReleaseUri = r.publishReleaseUri;
-          if (publishReleaseUri != null) {
-            tag = '[$tag]($publishReleaseUri)';
-          }
+  Iterable<Result> get visibleResults =>
+      results.where((r) => r.isVisibleInTable);
 
-          tagColumn = ' | $tag';
+  Iterable<Result> get hiddenResults =>
+      results.where((r) => !r.isVisibleInTable);
+
+  String describeAsMarkdown({bool withTag = true}) {
+    final buffer = StringBuffer();
+    for (final r in visibleResults) {
+      final sev = r.severity == Severity.error ? '(error) ' : '';
+      var tagColumn = '';
+      if (withTag) {
+        var tag = r.gitTag == null ? '' : '`${r.gitTag}`';
+        final publishReleaseUri = r.publishReleaseUri;
+        if (publishReleaseUri != null) {
+          tag = '[$tag]($publishReleaseUri)';
         }
-        return '| package:${r.package.name} | ${r.package.version} | '
-            '$sev${r.message}$tagColumn |';
-      }).join('\n');
+
+        tagColumn = ' | $tag';
+      }
+      buffer.writeln(
+        '| package:${r.package.name} | ${r.package.version} | '
+        '$sev${r.message}$tagColumn |',
+      );
+    }
+
+    final hidden = hiddenResults.toList();
+    final alreadyPublishedCount =
+        hidden.where((r) => r.message.startsWith('already published')).length;
+    final wipCount = hidden.where((r) => r.message.startsWith('WIP')).length;
+
+    final summaryLines = <String>[];
+    if (alreadyPublishedCount > 0) {
+      summaryLines.add('$alreadyPublishedCount already published.');
+    }
+    if (wipCount > 0) {
+      summaryLines.add('$wipCount WIP (no publish necessary).');
+    }
+
+    if (summaryLines.isNotEmpty) {
+      if (visibleResults.isNotEmpty) {
+        buffer.writeln();
+      }
+      buffer.write(summaryLines.join('\n'));
+    }
+
+    return buffer.toString().trimRight();
+  }
 }
 
 class Result {
@@ -346,6 +402,7 @@ class Result {
   final String message;
   final String? gitTag;
   final Uri? publishReleaseUri;
+  final bool isAffected;
 
   Result(
     this.severity,
@@ -353,21 +410,35 @@ class Result {
     this.message, [
     this.gitTag,
     this.publishReleaseUri,
+    this.isAffected = false,
   ]);
 
-  factory Result.fail(Package package, String message) =>
-      Result(Severity.error, package, message);
+  factory Result.fail(
+    Package package,
+    String message, {
+    bool isAffected = false,
+  }) =>
+      Result(Severity.error, package, message, null, null, isAffected);
 
-  factory Result.info(Package package, String message) =>
-      Result(Severity.info, package, message);
+  factory Result.info(
+    Package package,
+    String message, {
+    bool isAffected = false,
+  }) =>
+      Result(Severity.info, package, message, null, null, isAffected);
 
   factory Result.success(
     Package package,
-    String message, [
+    String message, {
     String? gitTag,
     Uri? publishReleaseUri,
-  ]) =>
-      Result(Severity.success, package, message, gitTag, publishReleaseUri);
+    bool isAffected = false,
+  }) =>
+      Result(Severity.success, package, message, gitTag, publishReleaseUri,
+          isAffected);
+
+  bool get isVisibleInTable =>
+      isAffected || severity == Severity.success || severity == Severity.error;
 
   @override
   String toString() {

--- a/pkgs/firehose/test/firehose_test.dart
+++ b/pkgs/firehose/test/firehose_test.dart
@@ -84,8 +84,8 @@ void main() {
       expect(markdown, isNot(contains('| package:package2 |')));
       expect(markdown, isNot(contains('| package:package3 |')));
 
-      expect(markdown, contains('1 already published.'));
-      expect(markdown, contains('2 WIP (no publish necessary).'));
+      expect(markdown, contains('* 1 already published.'));
+      expect(markdown, contains('* 2 WIP (no publish necessary).'));
     });
 
     test('summary omitted when counts are zero', () {
@@ -110,8 +110,10 @@ void main() {
       expect(results.hiddenResults.length, 2);
 
       final markdown = results.describeAsMarkdown(withTag: false);
-      expect(markdown,
-          equals('1 already published.\n1 WIP (no publish necessary).'));
+      expect(
+        markdown,
+        equals('* 1 already published.\n* 1 WIP (no publish necessary).'),
+      );
     });
   });
 

--- a/pkgs/firehose/test/firehose_test.dart
+++ b/pkgs/firehose/test/firehose_test.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:firehose/firehose.dart';
+import 'package:firehose/src/local_github_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VerificationResults', () {
+    late Repository repo;
+    late Package pkgA;
+    late Package pkgB;
+    late Package pkgC;
+    late Package pkgD;
+    late Package pkgE;
+
+    setUp(() {
+      repo = Repository();
+      pkgA = Package(Directory('test_data/workspace_repo/pkg_1'), repo);
+      pkgB = Package(Directory('test_data/workspace_repo/pkg_2'), repo);
+      pkgC = Package(Directory('test_data/test_repo/pkgs/package1'), repo);
+      pkgD = Package(Directory('test_data/test_repo/pkgs/package2'), repo);
+      pkgE = Package(Directory('test_data/test_repo/pkgs/package3'), repo);
+    });
+
+    test('all packages affected are visible in table', () {
+      final results = VerificationResults()
+        ..addResult(
+            Result.info(pkgA, 'WIP (no publish necessary)', isAffected: true))
+        ..addResult(Result.info(pkgB, 'already published at pub.dev',
+            isAffected: true));
+
+      expect(results.visibleResults.length, 2);
+      expect(results.hiddenResults, isEmpty);
+
+      final markdown = results.describeAsMarkdown(withTag: false);
+      expect(markdown, contains('| package:pkg_1 |'));
+      expect(markdown, contains('| package:pkg_2 |'));
+      expect(markdown, isNot(contains('already published.')));
+      expect(markdown, isNot(contains('WIP (no publish necessary).')));
+    });
+
+    test('unaffected ready-to-publish and error packages are in table', () {
+      final results = VerificationResults()
+        ..addResult(
+            Result.success(pkgA, '**ready to publish**', isAffected: false))
+        ..addResult(Result.fail(pkgB, 'version mismatch', isAffected: false));
+
+      expect(results.visibleResults.length, 2);
+      expect(results.hiddenResults, isEmpty);
+
+      final markdown = results.describeAsMarkdown(withTag: false);
+      expect(markdown, contains('| package:pkg_1 |'));
+      expect(markdown, contains('| package:pkg_2 |'));
+    });
+
+    test('unaffected WIP and already-published packages are summarized', () {
+      final results = VerificationResults()
+        ..addResult(
+            Result.success(pkgA, '**ready to publish**', isAffected: false))
+        ..addResult(
+            Result.info(pkgB, 'WIP (no publish necessary)', isAffected: true))
+        ..addResult(
+            Result.info(pkgC, 'WIP (no publish necessary)', isAffected: false))
+        ..addResult(
+            Result.info(pkgD, 'WIP (no publish necessary)', isAffected: false))
+        ..addResult(Result.info(pkgE, 'already published at pub.dev',
+            isAffected: false));
+
+      expect(results.visibleResults.length, 2);
+      expect(results.hiddenResults.length, 3);
+
+      final markdown = results.describeAsMarkdown(withTag: false);
+      expect(markdown, contains('| package:pkg_1 |'));
+      expect(markdown, contains('| package:pkg_2 |'));
+      expect(markdown, isNot(contains('| package:package1 |')));
+      expect(markdown, isNot(contains('| package:package2 |')));
+      expect(markdown, isNot(contains('| package:package3 |')));
+
+      expect(markdown, contains('1 already published.'));
+      expect(markdown, contains('2 WIP (no publish necessary).'));
+    });
+
+    test('summary omitted when counts are zero', () {
+      final results = VerificationResults()
+        ..addResult(
+            Result.success(pkgA, '**ready to publish**', isAffected: true));
+
+      final markdown = results.describeAsMarkdown(withTag: false);
+      expect(markdown, contains('| package:pkg_1 |'));
+      expect(markdown, isNot(contains('already published.')));
+      expect(markdown, isNot(contains('WIP (no publish necessary).')));
+    });
+
+    test('only summary when no packages visible in table', () {
+      final results = VerificationResults()
+        ..addResult(Result.info(pkgA, 'already published at pub.dev',
+            isAffected: false))
+        ..addResult(
+            Result.info(pkgB, 'WIP (no publish necessary)', isAffected: false));
+
+      expect(results.visibleResults, isEmpty);
+      expect(results.hiddenResults.length, 2);
+
+      final markdown = results.describeAsMarkdown(withTag: false);
+      expect(markdown,
+          equals('1 already published.\n1 WIP (no publish necessary).'));
+    });
+  });
+
+  group('Firehose.verify with LocalGithubApi', () {
+    test('filters packages based on PR file changes', () async {
+      final testDir = Directory('test_data/test_repo');
+      final firehose = Firehose(testDir, false, []);
+      final github = LocalGithubApi(
+        prLabels: [],
+        files: [
+          GitFile(
+            'pkgs/package1/lib/package1.dart',
+            FileStatus.modified,
+            testDir,
+          ),
+        ],
+      );
+
+      final results = await firehose.verify(github);
+      final affectedResults =
+          results.results.where((r) => r.isAffected).toList();
+      final unaffectedResults =
+          results.results.where((r) => !r.isAffected).toList();
+
+      expect(affectedResults.map((r) => r.package.name), ['package1']);
+      expect(
+        unaffectedResults.map((r) => r.package.name),
+        containsAll(['package2', 'package3', 'package4', 'package5']),
+      );
+    });
+  });
+}

--- a/pkgs/firehose/test/firehose_test.dart
+++ b/pkgs/firehose/test/firehose_test.dart
@@ -29,7 +29,7 @@ void main() {
       pkgE = Package(Directory('test_data/test_repo/pkgs/package3'), repo);
     });
 
-    test('all packages affected are visible in table', () {
+    test('all packages affected are visible in table and highlighted', () {
       final results = VerificationResults()
         ..addResult(
             Result.info(pkgA, 'WIP (no publish necessary)', isAffected: true))
@@ -40,13 +40,13 @@ void main() {
       expect(results.hiddenResults, isEmpty);
 
       final markdown = results.describeAsMarkdown(withTag: false);
-      expect(markdown, contains('| package:pkg_1 |'));
-      expect(markdown, contains('| package:pkg_2 |'));
+      expect(markdown, contains('| **package:pkg_1** ⭐ |'));
+      expect(markdown, contains('| **package:pkg_2** ⭐ |'));
       expect(markdown, isNot(contains('already published.')));
       expect(markdown, isNot(contains('WIP (no publish necessary).')));
     });
 
-    test('unaffected ready-to-publish and error packages are in table', () {
+    test('unaffected ready-to-publish and error packages are not starred', () {
       final results = VerificationResults()
         ..addResult(
             Result.success(pkgA, '**ready to publish**', isAffected: false))
@@ -58,6 +58,7 @@ void main() {
       final markdown = results.describeAsMarkdown(withTag: false);
       expect(markdown, contains('| package:pkg_1 |'));
       expect(markdown, contains('| package:pkg_2 |'));
+      expect(markdown, isNot(contains('⭐')));
     });
 
     test('unaffected WIP and already-published packages are summarized', () {
@@ -78,7 +79,7 @@ void main() {
 
       final markdown = results.describeAsMarkdown(withTag: false);
       expect(markdown, contains('| package:pkg_1 |'));
-      expect(markdown, contains('| package:pkg_2 |'));
+      expect(markdown, contains('| **package:pkg_2** ⭐ |'));
       expect(markdown, isNot(contains('| package:package1 |')));
       expect(markdown, isNot(contains('| package:package2 |')));
       expect(markdown, isNot(contains('| package:package3 |')));
@@ -93,7 +94,7 @@ void main() {
             Result.success(pkgA, '**ready to publish**', isAffected: true));
 
       final markdown = results.describeAsMarkdown(withTag: false);
-      expect(markdown, contains('| package:pkg_1 |'));
+      expect(markdown, contains('| **package:pkg_1** ⭐ |'));
       expect(markdown, isNot(contains('already published.')));
       expect(markdown, isNot(contains('WIP (no publish necessary).')));
     });

--- a/pkgs/firehose/test/firehose_test.dart
+++ b/pkgs/firehose/test/firehose_test.dart
@@ -31,9 +31,8 @@ void main() {
 
     test('all packages affected are visible in table and highlighted', () {
       final results = VerificationResults()
-        ..addResult(
-            Result.info(pkgA, 'WIP (no publish necessary)', isAffected: true))
-        ..addResult(Result.info(pkgB, 'already published at pub.dev',
+        ..addResult(Result.info(pkgA, Result.wipMessage, isAffected: true))
+        ..addResult(Result.info(pkgB, Result.alreadyPublishedMessage,
             isAffected: true));
 
       expect(results.visibleResults.length, 2);
@@ -65,13 +64,10 @@ void main() {
       final results = VerificationResults()
         ..addResult(
             Result.success(pkgA, '**ready to publish**', isAffected: false))
-        ..addResult(
-            Result.info(pkgB, 'WIP (no publish necessary)', isAffected: true))
-        ..addResult(
-            Result.info(pkgC, 'WIP (no publish necessary)', isAffected: false))
-        ..addResult(
-            Result.info(pkgD, 'WIP (no publish necessary)', isAffected: false))
-        ..addResult(Result.info(pkgE, 'already published at pub.dev',
+        ..addResult(Result.info(pkgB, Result.wipMessage, isAffected: true))
+        ..addResult(Result.info(pkgC, Result.wipMessage, isAffected: false))
+        ..addResult(Result.info(pkgD, Result.wipMessage, isAffected: false))
+        ..addResult(Result.info(pkgE, Result.alreadyPublishedMessage,
             isAffected: false));
 
       expect(results.visibleResults.length, 2);
@@ -101,10 +97,9 @@ void main() {
 
     test('only summary when no packages visible in table', () {
       final results = VerificationResults()
-        ..addResult(Result.info(pkgA, 'already published at pub.dev',
+        ..addResult(Result.info(pkgA, Result.alreadyPublishedMessage,
             isAffected: false))
-        ..addResult(
-            Result.info(pkgB, 'WIP (no publish necessary)', isAffected: false));
+        ..addResult(Result.info(pkgB, Result.wipMessage, isAffected: false));
 
       expect(results.visibleResults, isEmpty);
       expect(results.hiddenResults.length, 2);


### PR DESCRIPTION
Condense the package publishing table posted by firehose during PR validation to reduce noise in monorepos.

* Only include packages affected by the PR, packages ready to publish, and packages with validation errors in the markdown table.
* Summarize unaffected WIP and already published packages below the table.
* Add unit and integration tests covering table filtering and summary generation.
