### PR TITLE
chore(health): remove 3rd-party coveralls action dependency

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -25,7 +25,6 @@ name: Health
 #       fail_on: "changelog,do-not-submit"
 #       warn_on: "license,coverage,breaking,leaking"
 #       coverage_web: false
-#       upload_coverage: false
 #       flutter_packages: "pkgs/my_flutter_package"
 #       ignore_license: "**.g.dart"
 #       ignore_changelog: ""
@@ -79,11 +78,6 @@ on:
       local_debug:
         description: Whether to use a local copy of package:firehose - only for debug
         default: false
-        type: boolean
-        required: false
-      upload_coverage:
-        description: Whether to upload the coverage to coveralls
-        default: true
         type: boolean
         required: false
       coverage_web:
@@ -251,7 +245,6 @@ jobs:
       check: coverage
       fail_on: ${{ inputs.fail_on }}
       warn_on: ${{ inputs.warn_on }}
-      upload_coverage: ${{ inputs.upload_coverage }}
       coverage_web: ${{ inputs.coverage_web }}
       local_debug: ${{ inputs.local_debug }}
       flutter_packages: ${{ inputs.flutter_packages }}

--- a/.github/workflows/health_base.yaml
+++ b/.github/workflows/health_base.yaml
@@ -30,10 +30,6 @@ on:
         default: false
         type: boolean
         required: false
-      upload_coverage:
-        default: true
-        type: boolean
-        required: false
       coverage_web:
         default: false
         type: boolean
@@ -230,15 +226,6 @@ jobs:
         if: failure()
         env:
           INPUTS_CHECK: ${{ inputs.check }}
-
-      - name: Upload coverage to Coveralls
-        if: ${{ inputs.upload_coverage && inputs.check == 'coverage' }}
-        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
-        with:
-          format: lcov
-          base-path: current_repo/
-          compare-sha: ${{ github.event.pull_request.base.ref }}
-          allow-empty: true
 
       - name: Upload markdown
         if: success() || failure()

--- a/.github/workflows/health_internal.yaml
+++ b/.github/workflows/health_internal.yaml
@@ -19,6 +19,7 @@ jobs:
       warn_on: license,coverage,breaking,leaking,unused-dependencies
       ignore_license: 'pkgs/firehose/test_data'
       ignore_coverage: 'pkgs/firehose/bin,pkgs/firehose/test_data'
+      ignore_donotsubmit: 'pkgs/firehose/test_data'
       health_yaml_name: 'health_internal.yaml'
     permissions:
       pull-requests: write

--- a/.github/workflows/health_internal.yaml
+++ b/.github/workflows/health_internal.yaml
@@ -14,7 +14,6 @@ jobs:
       sdk: dev
       local_debug: true
       coverage_web: false
-      upload_coverage: false
       checks: changelog,license,coverage,breaking,do-not-submit,leaking,unused-dependencies
       fail_on: changelog,do-not-submit
       warn_on: license,coverage,breaking,leaking,unused-dependencies

--- a/.github/workflows/health_internal.yaml
+++ b/.github/workflows/health_internal.yaml
@@ -19,7 +19,7 @@ jobs:
       warn_on: license,coverage,breaking,leaking,unused-dependencies
       ignore_license: 'pkgs/firehose/test_data'
       ignore_coverage: 'pkgs/firehose/bin,pkgs/firehose/test_data'
-      ignore_donotsubmit: 'pkgs/firehose/test_data'
+      ignore_donotsubmit: 'pkgs/firehose/README.md,pkgs/firehose/test_data'
       health_yaml_name: 'health_internal.yaml'
     permissions:
       pull-requests: write

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.13.2-wip
 
+- Remove 3rd-party Coveralls action and `upload_coverage` input from health workflows.
 - Add `--tag-prefix` option to `firehose` and `tag-prefix` input to `publish.yaml` to allow configuring the release tag prefix (defaults to `'v'`).
 - Run `pub get` before `dart format` in `groundskeeper`.
 - Add `groundskeeper` executable to format and fix packages.

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -182,7 +182,6 @@ jobs:
 #     fail_on: "version,changelog,do-not-submit"
 #     warn_on: "license,coverage,breaking,leaking"
 #     coverage_web: false
-#     upload_coverage: false
 #     use-flutter: true
 #     ignore_license: "**.g.dart"
 #     ignore_coverage: "**.mock.dart,**.g.dart"
@@ -234,7 +233,6 @@ jobs:
 | `checks`  | List of strings  | What to check for in the PR health check | `"changelog,license,coverage,breaking,do-not-submit,leaking,unused-dependencies"` |
 | `fail_on`  | List of strings  | Which checks should lead to failure | `"changelog,do-not-submit"` |
 | `warn_on`  | List of strings  | Which checks should not fail, but only warn | `"license,coverage,breaking,leaking"` |
-| `upload_coverage`  | boolean  | Whether to upload the coverage to [coveralls](https://coveralls.io/) | `true` |
 | `coverage_web`  | boolean  | Whether to run `dart test -p chrome` for coverage | `false` |
 | `flutter_packages`  | List of strings  | List of packages depending on Flutter | `"pkgs/intl_flutter"` |
 | `ignore_*`  | List of globs | Files to ignore, where `*` can be `license`, `changelog`, `coverage`, `breaking`, `leaking`, `donotsubmit`, or `unuseddependencies`. For the `breaking` and `unuseddependencies` checks, the glob should be all files of the package. | `"**.g.dart"` |

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -156,7 +156,7 @@ When run from a PR, this tool will check a configurable subset of the following
 * All `.dart` files have a license header.
 * How the test coverage is affected by the PR.
 * The package versioning takes into account any breaking changes in the PR.
-* The PR contains `DO_NOT`_`SUBMIT` strings in the files or the description.
+* The PR contains `DO_NOT_SUBMIT` strings in the files or the description.
 * Any symbols are visible in the public API, but not exported.
 
 This tool can work with either single package repos or with mono-repos (repos
@@ -221,7 +221,7 @@ jobs:
 | **`license`** | Scans all `.dart` files in the PR to ensure they contain the required license header (e.g., the BSD 3-Clause header used by Dart ecosystem packages). |
 | **`coverage`** | Runs tests and calculates code coverage. It compares the coverage of the PR branch against the base branch to report whether coverage has increased, decreased, or stayed the same. |
 | **`breaking`** | Analyzes public API changes using `package:dart_apitool`. If breaking changes are detected (e.g., removing a class or changing a method signature), it ensures the version bump reflects a major/breaking change. |
-| **`do-not-submit`** | Scans the file contents and the PR description for the string `DO_NOT`_`SUBMIT`. This prevents developers from accidentally merging debug code, "TODO" shortcuts, or sensitive local configurations. |
+| **`do-not-submit`** | Scans the file contents and the PR description for the string `DO_NOT_SUBMIT`. This prevents developers from accidentally merging debug code, "TODO" shortcuts, or sensitive local configurations. |
 | **`leaking`** | Checks for "leaked" symbols—types or classes that are visible in your public API (e.g., used as a return type in a public method) but are not actually exported in your package's main library entry point. |
 | **`unused-dependencies`** | Analyzes the imports in your source code against the dependencies listed in `pubspec.yaml` to identify packages that are declared but never actually used, using `package:dependency_validator`. |
 

--- a/pkgs/firehose/README.md
+++ b/pkgs/firehose/README.md
@@ -156,7 +156,7 @@ When run from a PR, this tool will check a configurable subset of the following
 * All `.dart` files have a license header.
 * How the test coverage is affected by the PR.
 * The package versioning takes into account any breaking changes in the PR.
-* The PR contains `DO_NOT_SUBMIT` strings in the files or the description.
+* The PR contains `DO_NOT`_`SUBMIT` strings in the files or the description.
 * Any symbols are visible in the public API, but not exported.
 
 This tool can work with either single package repos or with mono-repos (repos
@@ -221,7 +221,7 @@ jobs:
 | **`license`** | Scans all `.dart` files in the PR to ensure they contain the required license header (e.g., the BSD 3-Clause header used by Dart ecosystem packages). |
 | **`coverage`** | Runs tests and calculates code coverage. It compares the coverage of the PR branch against the base branch to report whether coverage has increased, decreased, or stayed the same. |
 | **`breaking`** | Analyzes public API changes using `package:dart_apitool`. If breaking changes are detected (e.g., removing a class or changing a method signature), it ensures the version bump reflects a major/breaking change. |
-| **`do-not-submit`** | Scans the file contents and the PR description for the string `DO_NOT_SUBMIT`. This prevents developers from accidentally merging debug code, "TODO" shortcuts, or sensitive local configurations. |
+| **`do-not-submit`** | Scans the file contents and the PR description for the string `DO_NOT`_`SUBMIT`. This prevents developers from accidentally merging debug code, "TODO" shortcuts, or sensitive local configurations. |
 | **`leaking`** | Checks for "leaked" symbols—types or classes that are visible in your public API (e.g., used as a return type in a public method) but are not actually exported in your package's main library entry point. |
 | **`unused-dependencies`** | Analyzes the imports in your source code against the dependencies listed in `pubspec.yaml` to identify packages that are declared but never actually used, using `package:dependency_validator`. |
 


### PR DESCRIPTION
Remove coverallsapp/github-action and the upload_coverage input from
health workflows and documentation.

* Drop coverallsapp/github-action step from health_base.yaml
* Remove upload_coverage input from health.yaml, health_base.yaml, and health_internal.yaml
* Update pkgs/firehose/README.md documentation and options table
* Addresses enterprise security policy restrictions in Google/Flutter repositories (dart-lang/ecosystem#395)
