### PR TITLE
fix(firehose): update existing publishing PR comments when no packages are ready to publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Get comment id
         id: comment-id
-        if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments }}
+        if: ${{ inputs.write-comments }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -214,6 +214,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ steps.comment-id.outputs.comment }}
         run: dart pub global run firehose:comment create-or-update --comment-id "$COMMENT_ID" --body-path output/comment.md
+
+      - name: Delete comment
+        if: ${{ (hashFiles('output/comment.md') == '') && (hashFiles('output/commentId') != '') && inputs.write-comments && (steps.comment-id.outputs.comment != '') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ steps.comment-id.outputs.comment }}
+        run: dart pub global run firehose:comment delete --comment-id "$COMMENT_ID"
 
       - name: Save PR number
         if: ${{ !inputs.write-comments }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Get comment id
         id: comment-id
-        if: ${{ inputs.write-comments }}
+        if: ${{ (hashFiles('output/comment.md') != '') && inputs.write-comments }}
         run: |
           touch -a output/commentId
           COMMENT_ID=$(cat output/commentId)
@@ -214,13 +214,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ steps.comment-id.outputs.comment }}
         run: dart pub global run firehose:comment create-or-update --comment-id "$COMMENT_ID" --body-path output/comment.md
-
-      - name: Delete comment
-        if: ${{ (hashFiles('output/comment.md') == '') && (hashFiles('output/commentId') != '') && inputs.write-comments && (steps.comment-id.outputs.comment != '') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT_ID: ${{ steps.comment-id.outputs.comment }}
-        run: dart pub global run firehose:comment delete --comment-id "$COMMENT_ID"
 
       - name: Save PR number
         if: ${{ !inputs.write-comments }}

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.13.2-wip
 
-- Delete existing publishing PR comments when packages are no longer ready to
-  publish (e.g. when updated to `-wip`).
+- Update existing publishing PR comments with accurate status when packages are
+  no longer ready to publish (e.g. when updated to `-wip`).
 - Add `delete` command to `firehose:comment` executable.
 - Condense PR package publishing table to show only packages affected by the PR,
   packages ready to publish, and errors, summarizing unaffected WIP and published

--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.13.2-wip
 
+- Delete existing publishing PR comments when packages are no longer ready to
+  publish (e.g. when updated to `-wip`).
+- Add `delete` command to `firehose:comment` executable.
 - Condense PR package publishing table to show only packages affected by the PR,
   packages ready to publish, and errors, summarizing unaffected WIP and published
   packages.

--- a/pkgs/firehose/bin/comment.dart
+++ b/pkgs/firehose/bin/comment.dart
@@ -36,6 +36,8 @@ Future<void> main(List<String> arguments) async {
     await _findComment(command);
   } else if (command.name == 'create-or-update') {
     await _createOrUpdateComment(command);
+  } else if (command.name == 'delete') {
+    await _deleteComment(command);
   }
 }
 
@@ -53,6 +55,9 @@ ArgParser _createArgParser() {
     ..addOption('comment-id', help: 'Existing comment ID to update')
     ..addOption('body', help: 'Comment body text')
     ..addOption('body-path', help: 'Path to file containing comment body');
+
+  parser.addCommand('delete')
+    ..addOption('comment-id', help: 'Existing comment ID to delete');
 
   return parser;
 }
@@ -139,6 +144,28 @@ Future<void> _createOrUpdateComment(ArgResults results) async {
       await github.createComment(resolvedIssueNumber, body);
       print('Created comment');
     }
+  } finally {
+    github.close();
+  }
+}
+
+Future<void> _deleteComment(ArgResults results) async {
+  final commentId = results.option('comment-id') as String?;
+  if (commentId == null || commentId == '0' || commentId.isEmpty) {
+    stderr.writeln('Invalid comment ID: $commentId');
+    exitCode = 64;
+    return;
+  }
+  final id = int.tryParse(commentId);
+  if (id == null) {
+    stderr.writeln('Invalid comment ID: $commentId');
+    exitCode = 64;
+    return;
+  }
+  final github = GithubApi();
+  try {
+    await github.deleteComment(id);
+    print('Deleted comment $id');
   } finally {
     github.close();
   }

--- a/pkgs/firehose/bin/comment.dart
+++ b/pkgs/firehose/bin/comment.dart
@@ -56,8 +56,9 @@ ArgParser _createArgParser() {
     ..addOption('body', help: 'Comment body text')
     ..addOption('body-path', help: 'Path to file containing comment body');
 
-  parser.addCommand('delete')
-    ..addOption('comment-id', help: 'Existing comment ID to delete');
+  parser
+      .addCommand('delete')
+      .addOption('comment-id', help: 'Existing comment ID to delete');
 
   return parser;
 }
@@ -150,7 +151,7 @@ Future<void> _createOrUpdateComment(ArgResults results) async {
 }
 
 Future<void> _deleteComment(ArgResults results) async {
-  final commentId = results.option('comment-id') as String?;
+  final commentId = results.option('comment-id');
   if (commentId == null || commentId == '0' || commentId.isEmpty) {
     stderr.writeln('Invalid comment ID: $commentId');
     exitCode = 64;

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -80,18 +80,18 @@ Documentation at https://github.com/dart-lang/ecosystem/wiki/Publishing-automati
       logError: print,
     );
 
+    if (existingCommentId != null) {
+      final idFile = File('./output/commentId');
+      print('''
+Saving existing comment id $existingCommentId to file ${idFile.path}''');
+      await idFile.create(recursive: true);
+      await idFile.writeAsString(existingCommentId.toString());
+    }
+
     if (results.hasSuccess) {
       final commentText = '$_publishBotTag\n\n'
           '$_publishBotDescription\n\n'
           '$markdownTable';
-
-      if (existingCommentId != null) {
-        final idFile = File('./output/commentId');
-        print('''
-Saving existing comment id $existingCommentId to file ${idFile.path}''');
-        await idFile.create(recursive: true);
-        await idFile.writeAsString(existingCommentId.toString());
-      }
 
       final commentFile = File('./output/comment.md');
       print('Saving comment markdown to file ${commentFile.path}');

--- a/pkgs/firehose/lib/firehose.dart
+++ b/pkgs/firehose/lib/firehose.dart
@@ -88,19 +88,21 @@ Saving existing comment id $existingCommentId to file ${idFile.path}''');
       await idFile.writeAsString(existingCommentId.toString());
     }
 
-    if (results.hasSuccess) {
+    if (results.hasSuccess || existingCommentId != null) {
+      final description =
+          results.hasSuccess ? '$_publishBotDescription\n\n' : '';
       final commentText = '$_publishBotTag\n\n'
-          '$_publishBotDescription\n\n'
+          '$description'
           '$markdownTable';
 
       final commentFile = File('./output/comment.md');
       print('Saving comment markdown to file ${commentFile.path}');
       await commentFile.create(recursive: true);
       await commentFile.writeAsString(commentText);
-    } else {
-      if (results.hasError && exitCode == 0) {
-        exitCode = 1;
-      }
+    }
+
+    if (results.hasError && exitCode == 0) {
+      exitCode = 1;
     }
 
     github.close();

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -132,9 +132,8 @@ class GithubApi {
     await _github.issues.updateComment(_slug, commentId, body);
   }
 
-  Future<bool> deleteComment(int commentId) async {
-    return await _github.issues.deleteComment(_slug, commentId);
-  }
+  Future<bool> deleteComment(int commentId) async =>
+      await _github.issues.deleteComment(_slug, commentId);
 
   Future<List<GitFile>> listFilesForPR(
     Directory directory, [

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -132,8 +132,8 @@ class GithubApi {
     await _github.issues.updateComment(_slug, commentId, body);
   }
 
-  Future<bool> deleteComment(int commentId) async =>
-      await _github.issues.deleteComment(_slug, commentId);
+  Future<bool> deleteComment(int commentId) =>
+      _github.issues.deleteComment(_slug, commentId);
 
   Future<List<GitFile>> listFilesForPR(
     Directory directory, [

--- a/pkgs/firehose/lib/src/github.dart
+++ b/pkgs/firehose/lib/src/github.dart
@@ -132,6 +132,10 @@ class GithubApi {
     await _github.issues.updateComment(_slug, commentId, body);
   }
 
+  Future<bool> deleteComment(int commentId) async {
+    return await _github.issues.deleteComment(_slug, commentId);
+  }
+
   Future<List<GitFile>> listFilesForPR(
     Directory directory, [
     List<Glob> ignoredFiles = const [],

--- a/pkgs/firehose/lib/src/local_github_api.dart
+++ b/pkgs/firehose/lib/src/local_github_api.dart
@@ -45,9 +45,7 @@ class LocalGithubApi implements GithubApi {
   }
 
   @override
-  Future<bool> deleteComment(int commentId) async {
-    throw UnimplementedError();
-  }
+  Future<bool> deleteComment(int commentId) => throw UnimplementedError();
 
   @override
   String? get githubAuthToken => throw UnimplementedError();

--- a/pkgs/firehose/lib/src/local_github_api.dart
+++ b/pkgs/firehose/lib/src/local_github_api.dart
@@ -45,6 +45,11 @@ class LocalGithubApi implements GithubApi {
   }
 
   @override
+  Future<bool> deleteComment(int commentId) async {
+    throw UnimplementedError();
+  }
+
+  @override
   String? get githubAuthToken => throw UnimplementedError();
 
   @override

--- a/pkgs/firehose/test/firehose_test.dart
+++ b/pkgs/firehose/test/firehose_test.dart
@@ -140,4 +140,25 @@ void main() {
       );
     });
   });
+
+  group('bin/comment.dart CLI', () {
+    test('delete command exits with code 64 on missing or empty comment ID',
+        () async {
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['bin/comment.dart', 'delete', '--comment-id', '0'],
+      );
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('Invalid comment ID'));
+    });
+
+    test('delete command fails when required option is omitted', () async {
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['bin/comment.dart', 'delete'],
+      );
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('Invalid comment ID'));
+    });
+  });
 }


### PR DESCRIPTION
## Rationale
When a PR initially has a publishable version (e.g. `4.0.1-dev`) and firehose posts the `Package publishing` comment, but subsequently updates the package to a `-wip` version (e.g. `4.0.1-wip`), `VerificationResults.hasSuccess` becomes `false`.

Previously:
- In `lib/firehose.dart`, saving `existingCommentId` to `./output/commentId` and generating `./output/comment.md` was guarded strictly by `if (results.hasSuccess)`. When `hasSuccess` was `false`, neither file was written.
- As a result, the existing `Package publishing` comment with outdated `ready to publish` status and release links was never updated and remained on the PR indefinitely.

## Changes
- **`lib/firehose.dart`**: Save `existingCommentId` to `./output/commentId` unconditionally whenever an existing publishing comment is found. When `results.hasSuccess || existingCommentId != null`, write `./output/comment.md` with the updated `$markdownTable` (omitting the `"If you have publishing permissions..."` description when no packages are ready to publish).
- **`lib/src/github.dart`** & **`lib/src/local_github_api.dart`**: Add `deleteComment` helper to `GithubApi`.
- **`bin/comment.dart`**: Add `delete` subcommand (`firehose:comment delete --comment-id <id>`).
- **`test/firehose_test.dart`**: Add CLI argument validation and exit code tests for `comment delete`.
- **`CHANGELOG.md`**: Note that existing publishing PR comments are updated with accurate status when packages are no longer ready to publish.