### PR TITLE
fix(firehose): bump dependency_validator pinned hash to 5.0.6

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.13.2-wip
 
+- Update `dependency_validator` pinned commit hash to 5.0.6 (`7582a808960d2170800bfbd7a83526619ce300ce`),
+  enabling support for newer Dart syntax (up to analyzer 13).
 - Condense PR package publishing table to show only packages affected by the PR,
   packages ready to publish, and errors, summarizing unaffected WIP and published
   packages.

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -25,7 +25,7 @@ const dart_apitoolHash = '6d710709e5d51bab52ecd911c84a3264e5277a69';
 
 /// To allow easier searching for the package name
 // ignore: constant_identifier_names
-const dependency_validatorHash = 'f0a7e4ba6489d42f81a1352159c2f049c9741d4e';
+const dependency_validatorHash = '7582a808960d2170800bfbd7a83526619ce300ce';
 
 enum Check {
   license('License Headers', 'license'),


### PR DESCRIPTION
Update `dependency_validatorHash` in `lib/src/health/health.dart` to commit `7582a808960d2170800bfbd7a83526619ce300ce` (release 5.0.6).

This widens the allowed `package:analyzer` constraint up to version 13.x, preventing parse failures on newer Dart syntax (such as primary constructors) during the unused dependencies health check.

* Update `dependency_validatorHash` in `health.dart`
* Update `CHANGELOG.md`
