### PR TITLE
fix(firehose): bump dependency_validator to support analyzer 14

### DIFF
--- a/pkgs/firehose/CHANGELOG.md
+++ b/pkgs/firehose/CHANGELOG.md
@@ -3,8 +3,8 @@
 - Document Zizmor compatibility and ignore syntax for `post_summaries.yaml`.
 - Update `post_summaries.yaml` to resolve PR numbers for fork workflow runs via
   commit SHA, and verify comment authorship when checking `commentId`.
-- Update `dependency_validator` pinned commit hash to 5.0.6 (`7582a808960d2170800bfbd7a83526619ce300ce`),
-  enabling support for newer Dart syntax (up to analyzer 13).
+- Update `dependency_validator` pinned commit hash to `52f142e104371eab25d56cafef127ee53b715d22`,
+  enabling support for newer Dart syntax and analyzer 14 (e.g. `{@example}` doc directives).
 - Update existing publishing PR comments with accurate status when packages are
   no longer ready to publish (e.g. when updated to `-wip`).
 - Add `delete` command to `firehose:comment` executable.

--- a/pkgs/firehose/lib/src/health/health.dart
+++ b/pkgs/firehose/lib/src/health/health.dart
@@ -25,7 +25,7 @@ const dart_apitoolHash = '6d710709e5d51bab52ecd911c84a3264e5277a69';
 
 /// To allow easier searching for the package name
 // ignore: constant_identifier_names
-const dependency_validatorHash = '7582a808960d2170800bfbd7a83526619ce300ce';
+const dependency_validatorHash = '52f142e104371eab25d56cafef127ee53b715d22';
 
 enum Check {
   license('License Headers', 'license'),


### PR DESCRIPTION
### Warning - AI-generated

---

Update `dependency_validatorHash` in `pkgs/firehose/lib/src/health/health.dart` to commit [`52f142e104371eab25d56cafef127ee53b715d22`](https://github.com/Workiva/dependency_validator/commit/52f142e104371eab25d56cafef127ee53b715d22).

### Why
In #450, `dependency_validatorHash` was bumped to `7582a808960d2170800bfbd7a83526619ce300ce` (5.0.6 release tag). However, that tag constrained `analyzer: ">=7.1.0 <14.0.0"`, resolving `analyzer 13.3.0`.

`analyzer 13.x` reports unknown doc directives (`DOC_DIRECTIVE_UNKNOWN`), but support for `{@example}` doc directives was only added in `analyzer 14.1.0`. When `dependency_validator` parses files containing `{@example}` doc directives (like in `package:intl4x`), `parseString` throws an `ArgumentError` on the diagnostic, causing `dependency_validator` to crash and the `unused-dependencies` check to fail.

Commit `52f142e` in `Workiva/dependency_validator` widened the constraint to `analyzer: ">=7.1.0 <15.0.0"`, allowing it to resolve `analyzer 14.x` and parse `{@example}` doc directives without error.